### PR TITLE
optional markdownfmt

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -15,6 +15,7 @@ type cmdFlags struct {
 	documentationManifestPath    string
 	resourcesPath                string
 	resourceDownloadWorkersCount int
+	markdownFmt                  bool
 	ghOAuthToken                 string
 	dryRun                       bool
 	hugo                         bool
@@ -63,6 +64,8 @@ func (flags *cmdFlags) Configure(command *cobra.Command) {
 		"GitHub personal token authorizing reading from GitHub repos.")
 	command.Flags().BoolVar(&flags.failFast, "fail-fast", false,
 		"Fail-fast vs fault tolerant operation.")
+	command.Flags().BoolVar(&flags.markdownFmt, "markdownfmt", false,
+		"Applies formatting rules to source markdown.")
 	command.Flags().BoolVar(&flags.dryRun, "dry-run", false,
 		"Resolves and prints the resolved documentation structure without downloading anything.")
 	command.Flags().IntVar(&flags.minWorkersCount, "min-workers", 10,
@@ -93,6 +96,7 @@ func NewOptions(f *cmdFlags) *Options {
 		MinWorkersCount:              f.minWorkersCount,
 		ResourceDownloadWorkersCount: f.resourceDownloadWorkersCount,
 		ResourcesPath:                f.resourcesPath,
+		MarkdownFmt:                  f.markdownFmt,
 		Hugo:                         hugoOptions,
 	}
 }

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -25,6 +25,7 @@ type Options struct {
 	DestinationPath              string
 	ResourcesPath                string
 	ResourceDownloadWorkersCount int
+	MarkdownFmt                  bool
 	*Hugo
 }
 
@@ -53,7 +54,7 @@ func NewReactor(o *Options) *reactor.Reactor {
 					Root: o.DestinationPath,
 				},
 				Reader:               &reactor.GenericReader{},
-				NodeContentProcessor: reactor.NewNodeContentProcessor("/"+o.ResourcesPath, nil, downloadJob, o.FailFast),
+				NodeContentProcessor: reactor.NewNodeContentProcessor("/"+o.ResourcesPath, nil, downloadJob, o.FailFast, o.MarkdownFmt),
 			},
 		},
 	}

--- a/pkg/reactor/integration_test.go
+++ b/pkg/reactor/integration_test.go
@@ -61,6 +61,7 @@ func TestReactorWithGitHub(t *testing.T) {
 	destination := "../../example/hugo/content"
 	resourcesRoot := "__resources"
 	failFast := false
+	markdownFmt := false
 	downloadJob := NewResourceDownloadJob(nil, &writers.FSWriter{
 		Root: filepath.Join(destination, resourcesRoot),
 		//TMP
@@ -77,51 +78,10 @@ func TestReactorWithGitHub(t *testing.T) {
 					Root: destination,
 				},
 				Reader:               &GenericReader{},
-				NodeContentProcessor: NewNodeContentProcessor("/"+resourcesRoot, nil, downloadJob, failFast),
+				NodeContentProcessor: NewNodeContentProcessor("/"+resourcesRoot, nil, downloadJob, failFast, markdownFmt),
 			},
 		},
 	}
-
-	// if o.Hugo != nil {
-	// 	if worker, ok := r.ReplicateDocumentation.Worker.(*DocumentWorker); ok {
-	// 		worker.Processor = &processors.ProcessorChain{
-	// 			Processors: []processors.Processor{
-	// 				&processors.FrontMatter{},
-	// 				&processors.HugoProcessor{
-	// 					PrettyUrls: true,
-	// 				},
-	// 			},
-	// 		}
-	// 	}
-
-	// }
-
-	// resourcesRoot := "__resources"
-	// downloadJob := reactor.NewResourceDownloadJob(nil, &writers.FSWriter{
-	// 	Root: filepath.Join("../../example/hugo/content/", resourcesRoot),
-	// }, 5, failFast)
-	// failFast := false
-	// reactor := Reactor{
-	// 	ReplicateDocumentation: &jobs.Job{
-	// 		MaxWorkers: 50,
-	// 		FailFast:   failFast,
-	// 		Worker: &DocumentWorker{
-	// 			Writer: &writers.FSWriter{
-	// 				Root: "../../example/hugo/content",
-	// 			},
-	// 			Reader: &GenericReader{},
-	// 			Processor: &processors.ProcessorChain{
-	// 				Processors: []processors.Processor{
-	// 					&processors.FrontMatter{},
-	// 					&processors.HugoProcessor{
-	// 						PrettyUrls: true,
-	// 					},
-	// 				},
-	// 				NodeContentProcessor: NewNodeContentProcessor("/"+resourcesRoot, nil, downloadJob, failFast),
-	// 			},
-	// 		},
-	// 	},
-	// }
 
 	docs := &api.Documentation{Root: node}
 	if err := r.Run(ctx, docs, false); err != nil {


### PR DESCRIPTION
Currently, while reconciling links, markdown is parsed and written back according to opinionated format rules. This means that in the resulting markdown not only links will be different but more.
There are also several deficiencies, most notably lack of tables and front-matter support.
While this can evolve in markdownftm-like governance it is still premature and in addition it may be a prohibitive to use behavior in certain use cases that require minimal changes.

This PR makes the current behavior optional, controlled by the new `--markdownfmt` flag defaulting to false. 

It's notable that the implemented alternative also has deficiencies. It is realized with Go regular expressions that do not support sufficiently many options to capture all options for specifying a link in markdown. Currently, the supported link types without `-- markdownfmt` are:
- [text](url)
- [text](url title)    

Whitespace and parentheses in title will also have negative effect.
