### PR TITLE
Added update-release step in release job

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -44,3 +44,8 @@ docforge:
             internal_scp_workspace:
               channel_name: "G0170ECNADC" #gardener-space-sofia
               slack_cfg_name: "ti_workspace"
+      steps:
+        update-release:
+          execute: 'update-release.py'
+          inputs:
+            BINARY_PATH: 'binary'

--- a/.ci/update-release.py
+++ b/.ci/update-release.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import pathlib
+import util
+
+from github.util import GitHubRepositoryHelper
+from os import walk
+
+VERSION_FILE_NAME='VERSION'
+
+repo_owner_and_name = util.check_env('SOURCE_GITHUB_REPO_OWNER_AND_NAME')
+repo_dir = util.check_env('MAIN_REPO_DIR')
+output_dir = util.check_env('BINARY_PATH')
+
+repo_owner, repo_name = repo_owner_and_name.split('/')
+
+repo_path = pathlib.Path(repo_dir).resolve()
+output_path = pathlib.Path(output_dir).resolve()
+version_file_path = repo_path / VERSION_FILE_NAME
+
+version_file_contents = version_file_path.read_text()
+
+cfg_factory = util.ctx().cfg_factory()
+github_cfg = cfg_factory.github('github_com')
+
+github_repo_helper = GitHubRepositoryHelper(
+    owner=repo_owner,
+    name=repo_name,
+    github_cfg=github_cfg,
+)
+
+gh_release = github_repo_helper.repository.release_from_tag(version_file_contents)
+
+for dir, dirs, files in os.walk(join(output_path, "bin", "rel")):
+    for binName in files:
+        binFilePath = join(dir, binName)
+        gh_release.upload_asset(
+            content_type='application/octet-stream',
+            name=f'{binName}',
+            asset=binFilePath.open(mode='rb'),
+        )


### PR DESCRIPTION
**What this PR does / why we need it**:
The release job currently does not include the built binaries as release assets and the only way for consumers to use the tool is to build it themselves or use a published image in GCR.