### PR TITLE
Writing files

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -83,7 +83,7 @@ func (flags *cmdFlags) Configure(command *cobra.Command) {
 		"Build documentation bundle for hugo.")
 	command.Flags().BoolVar(&flags.hugoPrettyUrls, "hugo-pretty-urls", true,
 		"Build documentation bundle for hugo with pretty URLs (./sample.md -> ../sample). Only useful with --hugo=true")
-	command.Flags().StringSliceVar(&flags.hugoSectionFiles, "hugo-section-files", []string{"readme", "read.me", "_index", "index"},
+	command.Flags().StringSliceVar(&flags.hugoSectionFiles, "hugo-section-files", []string{"readme", "read.me", "index"},
 		"When building a Hugo-compliant documentaton bundle, files with filename matching one form this list (in that order) will be renamed to _index.md. Only useful with --hugo=true")
 }
 

--- a/pkg/api/nodes.go
+++ b/pkg/api/nodes.go
@@ -114,6 +114,21 @@ func (n *Node) GetRootNode() *Node {
 	return nil
 }
 
+// Peers returns the peer nodes of the node
+func (n *Node) Peers() []*Node {
+	var parent *Node
+	if parent = n.Parent(); parent == nil {
+		return nil
+	}
+	peers := []*Node{}
+	for _, node := range parent.Nodes {
+		if node != n {
+			peers = append(peers, node)
+		}
+	}
+	return peers
+}
+
 // FindNodeByContentSource traverses up and then all around the
 // tree paths in the node's documentation strcuture, looking for
 // a node that has contentSource path nodeContentSource

--- a/pkg/hugo/fswriter_test.go
+++ b/pkg/hugo/fswriter_test.go
@@ -1,0 +1,126 @@
+package hugo
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gardener/docforge/pkg/api"
+	"github.com/gardener/docforge/pkg/writers"
+	"github.com/google/uuid"
+)
+
+func TestWrite(t *testing.T) {
+	testCases := []struct {
+		name         string
+		path         string
+		docBlob      []byte
+		node         *api.Node
+		wantErr      error
+		wantFileName string
+		wantContent  string
+		mutate       func(writer *FSWriter)
+	}{
+		{
+			name:         "test.md",
+			path:         "a/b",
+			docBlob:      []byte("# Test"),
+			wantErr:      nil,
+			wantFileName: `test.md`,
+			wantContent:  `# Test`,
+		},
+		{
+			name:         "test",
+			path:         "a/b",
+			docBlob:      []byte("# Test"),
+			node:         &api.Node{},
+			wantErr:      nil,
+			wantFileName: `test.md`,
+			wantContent:  `# Test`,
+		},
+		{
+			name:    "test",
+			path:    "a/b",
+			docBlob: nil,
+			node: &api.Node{
+				Properties: map[string]interface{}{
+					"frontmatter": map[string]string{
+						"title": "Test1",
+					},
+				},
+			},
+			wantErr:      nil,
+			wantFileName: filepath.Join("test", "_index.md"),
+			wantContent: `---
+title: Test1
+---
+`,
+		},
+		{
+			name:    "README",
+			path:    "a/b",
+			docBlob: []byte("# Test"),
+			node: &api.Node{
+				Name: "README",
+				Properties: map[string]interface{}{
+					"index": true,
+				},
+				ContentSelectors: []api.ContentSelector{
+					api.ContentSelector{
+						Source: "github.com",
+					},
+				},
+			},
+			wantErr:      nil,
+			wantFileName: filepath.Join("_index.md"),
+			wantContent:  `# Test`,
+			mutate: func(writer *FSWriter) {
+				writer.IndexFileNames = []string{"readme"}
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			testFolder := fmt.Sprintf("test%s", uuid.New().String())
+			testPath := filepath.Join(os.TempDir(), testFolder)
+			fs := &FSWriter{
+				Writer: &writers.FSWriter{
+					Root: testPath,
+				},
+			}
+			if tc.mutate != nil {
+				tc.mutate(fs)
+			}
+			fPath := filepath.Join(testPath, tc.path, tc.wantFileName)
+			defer func() {
+				if err := os.RemoveAll(testPath); err != nil {
+					t.Fatalf("%v\n", err)
+				}
+			}()
+
+			if tc.node != nil {
+				tc.node.SetParentsDownwards()
+			}
+			err := fs.Write(tc.name, tc.path, tc.docBlob, tc.node)
+
+			if err != tc.wantErr {
+				t.Errorf("expected err %v != %v", tc.wantErr, err)
+			}
+			if _, err := os.Stat(fPath); tc.wantErr == nil && os.IsNotExist(err) {
+				t.Errorf("expected file %s not found: %v", fPath, err)
+			}
+			var (
+				gotContent []byte
+			)
+			if gotContent, err = ioutil.ReadFile(fPath); err != nil {
+				t.Errorf("unexpected error opening file %v", err)
+			}
+			if !reflect.DeepEqual(gotContent, []byte(tc.wantContent)) {
+				t.Errorf("expected content \n%v\n != \n%v\n", tc.wantContent, string(gotContent))
+			}
+		})
+	}
+}

--- a/pkg/markdown/util_test.go
+++ b/pkg/markdown/util_test.go
@@ -1,102 +1,75 @@
 package markdown
 
 import (
-	"errors"
 	"testing"
 )
 
 func TestStripFrontMatter(t *testing.T) {
-
-	in := `---
+	testCases := []struct {
+		in          string
+		wantFM      string
+		wantContent string
+		wantErr     error
+	}{
+		{
+			in: `---
 title: Test
 prop: A
 ---
 
 # Head 1
-`
-	wantFM := `title: Test
+`,
+			wantFM: `title: Test
 prop: A
-`
-	wantContent := `
+`,
+			wantContent: `
 # Head 1
-`
-	var wantErr error
-
-	fm, c, err := StripFrontMatter([]byte(in))
-	if err != wantErr {
-		t.Errorf("expected err %v != %v", err, wantErr)
-	}
-	if string(fm) != wantFM {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantFM, fm)
-	}
-	if string(c) != wantContent {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantContent, c)
-	}
-}
-
-func TestStripFrontMatterNoFM(t *testing.T) {
-
-	in := `# Head 1`
-	wantFM := ""
-	wantContent := `# Head 1`
-	var wantErr error
-
-	fm, c, err := StripFrontMatter([]byte(in))
-	if err != wantErr {
-		t.Errorf("expected err %v != %v", err, wantErr)
-	}
-	if string(fm) != wantFM {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantFM, fm)
-	}
-	if string(c) != wantContent {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantContent, c)
-	}
-}
-
-func TestStripFrontMatterErr(t *testing.T) {
-
-	in := `
----
+`,
+		},
+		{
+			in:          `# Head 1`,
+			wantFM:      "",
+			wantContent: `# Head 1`,
+		},
+		{
+			in: `---
 Title: A
-`
-	wantFM := ""
-	wantContent := ""
-	wantErr := errors.New("Missing closing front-matter `---` mark found")
-
-	fm, c, err := StripFrontMatter([]byte(in))
-	if err.Error() != wantErr.Error() {
-		t.Errorf("expected err %v != %v", err, wantErr)
-	}
-	if string(fm) != wantFM {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantFM, fm)
-	}
-	if string(c) != wantContent {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantContent, c)
-	}
-}
-
-func TestStripFrontMatterNoErr(t *testing.T) {
-
-	in := `
-Some text
+`,
+			wantFM:      "",
+			wantContent: "",
+			wantErr:     ErrFrontMatterNotClosed,
+		},
+		{
+			in: `Some text
 
 ---
-`
-	wantFM := ""
-	wantContent := `
-Some text
+`,
+			wantFM: "",
+			wantContent: `Some text
 
 ---
-`
-
-	fm, c, err := StripFrontMatter([]byte(in))
-	if err != nil {
-		t.Errorf("expected err nil != %v", err)
+`,
+		},
+		{
+			in: `---
+title: Core Components
+---`,
+			wantFM:      "title: Core Components\n",
+			wantContent: "",
+		},
 	}
-	if string(fm) != wantFM {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantFM, fm)
-	}
-	if string(c) != wantContent {
-		t.Errorf("\nwant:\n%s\ngot:\n%s\n", wantContent, c)
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			fm, c, err := StripFrontMatter([]byte(tc.in))
+			if err != tc.wantErr {
+				t.Errorf("expected err %v != %v", tc.wantErr, err)
+			}
+			if string(fm) != tc.wantFM {
+				t.Errorf("\nwant frontmatter:\n%s\ngot:\n%s\n", tc.wantFM, fm)
+			}
+			if string(c) != tc.wantContent {
+				t.Errorf("\nwant content:\n%s\ngot:\n%s\n", tc.wantContent, c)
+			}
+		})
 	}
 }

--- a/pkg/processors/frontmatter_test.go
+++ b/pkg/processors/frontmatter_test.go
@@ -1,0 +1,98 @@
+package processors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gardener/docforge/pkg/api"
+)
+
+func TestFrontmatterProcess(t *testing.T) {
+	testCases := []struct {
+		document     string
+		node         *api.Node
+		wantErr      error
+		wantDocument string
+	}{
+		{
+			document: "",
+			node: &api.Node{
+				Name: "test",
+			},
+			wantErr: nil,
+			wantDocument: `---
+title: Test
+---
+`,
+		},
+		{
+			document: "# Heading",
+			node: &api.Node{
+				Name: "test",
+				Properties: map[string]interface{}{
+					"frontmatter": map[string]interface{}{
+						"title": "Test1",
+					},
+				},
+			},
+			wantErr: nil,
+			wantDocument: `---
+title: Test1
+---
+# Heading`,
+		},
+		{
+			document: `---
+prop1: A
+---
+
+# Heading`,
+			node: &api.Node{
+				Name: "test",
+				Properties: map[string]interface{}{
+					"frontmatter": map[string]interface{}{
+						"title": "Test",
+					},
+				},
+			},
+			wantErr: nil,
+			wantDocument: `---
+prop1: A
+title: Test
+---
+
+# Heading`,
+		},
+		{
+			document: `---
+title: Test1
+---`,
+			node: &api.Node{
+				Name: "test3",
+				Properties: map[string]interface{}{
+					"frontmatter": map[string]interface{}{
+						"title": "Test2",
+					},
+				},
+			},
+			wantErr: nil,
+			wantDocument: `---
+title: Test1
+title: Test2
+---
+`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			fm := &FrontMatter{}
+			gotDocumentBlob, err := fm.Process([]byte(tc.document), tc.node)
+			if err != tc.wantErr {
+				t.Errorf("expected err %v!=%v", tc.wantErr, err)
+			}
+			if !reflect.DeepEqual(string(gotDocumentBlob), tc.wantDocument) {
+				t.Errorf("expected bytes \n%s\n!=\n%s\n", tc.wantDocument, string(gotDocumentBlob))
+			}
+		})
+	}
+}

--- a/pkg/reactor/document_worker.go
+++ b/pkg/reactor/document_worker.go
@@ -49,53 +49,53 @@ func (g *GenericReader) Read(ctx context.Context, source string) ([]byte, error)
 // Work implements Worker#Work function
 func (w *DocumentWorker) Work(ctx context.Context, task interface{}) *jobs.WorkerError {
 	var (
-		t  *DocumentWorkTask
-		ok bool
+		t          *DocumentWorkTask
+		ok         bool
+		sourceBlob []byte
 	)
 	if t, ok = task.(*DocumentWorkTask); !ok {
 		return jobs.NewWorkerError(fmt.Errorf("cast failed: %v", task), 0)
 	}
 
-	if len(t.Node.ContentSelectors) < 1 {
-		return nil
-	}
-	// Write the document content
-	blobs := make(map[string][]byte)
-	for _, content := range t.Node.ContentSelectors {
-		sourceBlob, err := w.Reader.Read(ctx, content.Source)
-		if len(sourceBlob) == 0 {
-			fmt.Printf("No bytes read from source %s\n", content.Source)
-			continue
+	if len(t.Node.ContentSelectors) > 0 {
+		// Write the document content
+		blobs := make(map[string][]byte)
+		for _, content := range t.Node.ContentSelectors {
+			sourceBlob, err := w.Reader.Read(ctx, content.Source)
+			if len(sourceBlob) == 0 {
+				fmt.Printf("No bytes read from source %s\n", content.Source)
+				continue
+			}
+			if err != nil {
+				return jobs.NewWorkerError(err, 0)
+			}
+			newBlob, err := w.NodeContentProcessor.ReconcileLinks(ctx, t.Node, content.Source, sourceBlob)
+			if err != nil {
+				return jobs.NewWorkerError(err, 0)
+			}
+			blobs[content.Source] = newBlob
 		}
-		if err != nil {
-			return jobs.NewWorkerError(err, 0)
+
+		if len(blobs) == 0 {
+			return nil
 		}
-		newBlob, err := w.NodeContentProcessor.ReconcileLinks(ctx, t.Node, content.Source, sourceBlob)
-		if err != nil {
-			return jobs.NewWorkerError(err, 0)
+
+		for _, blob := range blobs {
+			sourceBlob = append(sourceBlob, blob...)
 		}
-		blobs[content.Source] = newBlob
-	}
 
-	if len(blobs) == 0 {
-		return nil
-	}
-
-	var sourceBlob []byte
-	for _, blob := range blobs {
-		sourceBlob = append(sourceBlob, blob...)
-	}
-
-	var err error
-	if w.Processor != nil {
-		if sourceBlob, err = w.Processor.Process(sourceBlob, t.Node); err != nil {
-			return jobs.NewWorkerError(err, 0)
+		var err error
+		if w.Processor != nil {
+			if sourceBlob, err = w.Processor.Process(sourceBlob, t.Node); err != nil {
+				return jobs.NewWorkerError(err, 0)
+			}
 		}
 	}
 
 	path := utilnode.Path(t.Node, "/")
-	if err := w.Writer.Write(t.Node.Name, path, sourceBlob); err != nil {
+	if err := w.Writer.Write(t.Node.Name, path, sourceBlob, t.Node); err != nil {
 		return jobs.NewWorkerError(err, 0)
 	}
+
 	return nil
 }

--- a/pkg/reactor/document_worker_test.go
+++ b/pkg/reactor/document_worker_test.go
@@ -16,7 +16,7 @@ type TestWriter struct {
 	output map[string][]byte
 }
 
-func (w *TestWriter) Write(name, path string, resourceContent []byte) error {
+func (w *TestWriter) Write(name, path string, resourceContent []byte, node *api.Node) error {
 	w.output[fmt.Sprintf("%s/%s", path, name)] = resourceContent
 	return nil
 }

--- a/pkg/reactor/reactor.go
+++ b/pkg/reactor/reactor.go
@@ -125,11 +125,11 @@ func (r *Reactor) Resolve(ctx context.Context, node *api.Node) error {
 
 func tasks(node *api.Node, t *[]interface{}) {
 	n := node
-	if len(n.ContentSelectors) > 0 {
-		*t = append(*t, &DocumentWorkTask{
-			Node: n,
-		})
-	}
+	// if len(n.ContentSelectors) > 0 {
+	*t = append(*t, &DocumentWorkTask{
+		Node: n,
+	})
+	// }
 	if node.Nodes != nil {
 		for _, n := range node.Nodes {
 			tasks(n, t)

--- a/pkg/reactor/resource_download.go
+++ b/pkg/reactor/resource_download.go
@@ -144,7 +144,7 @@ func (d *downloadWorker) download(ctx context.Context, dt *DownloadTask) error {
 		return err
 	}
 
-	if err := d.Writer.Write(dt.Target, "", blob); err != nil {
+	if err := d.Writer.Write(dt.Target, "", blob, nil); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/resourcehandlers/github/integration_test.go
+++ b/pkg/resourcehandlers/github/integration_test.go
@@ -31,7 +31,9 @@ func TestResolveNodeSelectorLive(t *testing.T) {
 	)
 	gh := &GitHub{
 		Client: github.NewClient(oauth2.NewClient(ctx, ts)),
-		cache:  Cache{},
+		cache: &Cache{
+			cache: map[string]*ResourceLocator{},
+		},
 	}
 	node := &api.Node{
 		Name: "docs",

--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -5,6 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/gardener/docforge/pkg/api"
 )
 
 // FSWriter is implementation of Writer interface for writing blobs to the file system
@@ -12,18 +15,23 @@ type FSWriter struct {
 	Root string
 }
 
-func (f *FSWriter) Write(name, path string, docBlob []byte) error {
-	fmt.Printf("Writing %s \n", filepath.Join(f.Root, path, name))
-	if len(docBlob) <= 0 {
-		return nil
-	}
+func (f *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) error {
 	p := filepath.Join(f.Root, path)
-	if _, err := os.Stat(p); os.IsNotExist(err) {
-		if err = os.MkdirAll(p, os.ModePerm); err != nil {
+	if len(docBlob) <= 0 {
+		if err := os.MkdirAll(p, os.ModePerm); err != nil {
 			return err
 		}
+		return nil
+	}
+	if err := os.MkdirAll(p, os.ModePerm); err != nil {
+		return err
+	}
+
+	if node != nil && !strings.HasSuffix(name, ".md") {
+		name = fmt.Sprintf("%s.md", name)
 	}
 	filePath := filepath.Join(p, name)
+
 	if err := ioutil.WriteFile(filePath, docBlob, 0644); err != nil {
 		fmt.Printf("Error writing %s: %v\n", filepath.Join(f.Root, path, name), err)
 		return err

--- a/pkg/writers/fswriter_test.go
+++ b/pkg/writers/fswriter_test.go
@@ -1,0 +1,68 @@
+package writers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gardener/docforge/pkg/api"
+	"github.com/google/uuid"
+)
+
+func TestWrite(t *testing.T) {
+	testCases := []struct {
+		name         string
+		path         string
+		docBlob      []byte
+		node         *api.Node
+		wantErr      error
+		wantFileName string
+		wantContent  string
+	}{
+		{
+			name:         "test",
+			path:         "a/b",
+			docBlob:      []byte("# Test"),
+			node:         &api.Node{},
+			wantErr:      nil,
+			wantFileName: `test.md`,
+			wantContent:  `# Test`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			testFolder := fmt.Sprintf("test%s", uuid.New().String())
+			testPath := filepath.Join(os.TempDir(), testFolder)
+			fs := &FSWriter{
+				Root: testPath,
+			}
+			fPath := filepath.Join(fs.Root, tc.path, tc.wantFileName)
+			defer func() {
+				if err := os.RemoveAll(testPath); err != nil {
+					t.Fatalf("%v\n", err)
+				}
+			}()
+
+			err := fs.Write(tc.name, tc.path, tc.docBlob, tc.node)
+
+			if err != tc.wantErr {
+				t.Errorf("expected err %v != %v", tc.wantErr, err)
+			}
+			if _, err := os.Stat(fPath); tc.wantErr == nil && os.IsNotExist(err) {
+				t.Errorf("expected file to be written, but it was not")
+			}
+			var (
+				b []byte
+			)
+			if b, err = ioutil.ReadFile(fPath); err != nil {
+				t.Errorf("unexppected error opening file %v", err)
+			}
+			if !reflect.DeepEqual(b, []byte(tc.wantContent)) {
+				t.Errorf("expected content %v != %v", tc.wantContent, tc.wantContent)
+			}
+		})
+	}
+}

--- a/pkg/writers/writers.go
+++ b/pkg/writers/writers.go
@@ -1,6 +1,8 @@
 package writers
 
+import "github.com/gardener/docforge/pkg/api"
+
 // Writer writes blobs with name to a given path
 type Writer interface {
-	Write(name, path string, resourceContent []byte) error
+	Write(name, path string, resourceContent []byte, node *api.Node) error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, writing files and folders doesn't quite work as expected.
- Duplicate writes for files and folders
- Concurrent map writes occur
- Nodes that do not refer to documents are not handled
among others.

What we want is a more reliable, manifest-driven materialization of the structure. And as far as hugo is concerned, smarter handling of _index.md files.

**Special notes for your reviewer**:

**Release note**:
```noteworthy user
Documents structures support "folder"-type nodes that have no contentSelector specified and result in a file folder named by the name of the node.
```
```noteworthy user
- Node names need not end with .md suffix to have the file written as<name>.md. If there is no .md suffix, it will be appended to the file name prior to writing it down.
```
```noteworthy user
Hugo support  
The following features are available when the `--hugo=true` option flag is enabled:  
- Frontmatter that should be written to a document is specified in the properties map of the corresponding documentation structure node with key "frontmatter"
- Documents frontmatter in yaml (only) is supported
- Documents with frontmatter only (no other content) and without line ending on the last line are supported.
- Documents with frontmatter preceded by any amount of whitespace are supported. Whitespace before or after the `---` start/end marks is also supported.
- Documents that start with `---` (potentially preceded by any whitespace) are considered to specify frontmatter. An error is thrown if there is no closing `---` and the content in between is not valid yaml
- Frontmatter specified as node property and frontmatter available in the node document that will be written are merged. Duplicates are not reconciled.
- A minimal frontmatter `title: <node-name-title-case>` is written when no other has been specified as node property or in the document)
- Container nodes that specify a "frontmatter" structure in their `properties` will be written as folders with autogenerated `_index.md` file that contains the specified frontmatter.
- Document nodes that need to be written as hugo section files are identified by an `index": true` entry in their Properties. Such nodes are written as _index.md files regardless of their name.
- A section file node can be inferred automatically too. A document structure node that has content selectors, and with no other peer nodes named `_index` or `_index_md`, will be written as `_index.md` file, provided that its name matches one of the entries specified in the `--hugo-section-files` flag or its default list: readme, read.me, index (case insensitive). To disable this automation, set the `--hugo-section-files` flag value to empty string. 
- Multiple files that will potentially be written as `_index.md` in the same folder are detected and reported as error.
```