### PR TITLE
Apply klog as logging solution

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gardener/docforge/pkg/hugo"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 )
 
 type cmdFlags struct {
@@ -47,6 +48,7 @@ func NewCommand(ctx context.Context, cancel context.CancelFunc) *cobra.Command {
 	version := NewVersionCmd()
 	cmd.AddCommand(version)
 
+	klog.InitFlags(nil)
 	AddFlags(cmd)
 
 	return cmd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,9 @@ func main() {
 	}()
 
 	command := app.NewCommand(ctx, cancel)
-	flag.CommandLine.Parse([]string{})
+	if err := flag.CommandLine.Parse([]string{}); err != nil {
+		panic(err.Error())
+	}
 	if err := command.Execute(); err != nil {
 		os.Exit(-1)
 	}

--- a/pkg/hugo/fswriter.go
+++ b/pkg/hugo/fswriter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gardener/docforge/pkg/markdown"
 	"gopkg.in/yaml.v3"
+	"k8s.io/klog/v2"
 
 	"github.com/gardener/docforge/pkg/api"
 	nodeutil "github.com/gardener/docforge/pkg/util/node"
@@ -64,7 +65,7 @@ func (w *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 		if len(w.IndexFileNames) > 0 && name != "_index" && name != "_index.md" && !hasIndexNode(peerNodes) {
 			for _, s := range w.IndexFileNames {
 				if strings.ToLower(name) == s {
-					fmt.Printf("Renaming %s -> _index.md\n", filepath.Join(path, name))
+					klog.V(6).Infof("Renaming %s -> _index.md\n", filepath.Join(path, name))
 					name = "_index"
 				}
 			}

--- a/pkg/hugo/processor.go
+++ b/pkg/hugo/processor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/markdown"
+	"k8s.io/klog/v2"
 
 	mdutil "github.com/gardener/docforge/pkg/markdown"
 )
@@ -62,7 +63,7 @@ func (f *Processor) rewriteDestination(destination []byte, nodeName string) ([]b
 	link = strings.TrimSuffix(strings.TrimPrefix(link, "\""), "\"")
 	u, err := url.Parse(link)
 	if err != nil {
-		fmt.Printf("Invalid link: %s", link)
+		klog.V(2).Infoln("Invalid link:", link)
 		return destination, nil
 	}
 	if !u.IsAbs() && !strings.HasPrefix(link, "/") && !strings.HasPrefix(link, "#") {
@@ -89,7 +90,7 @@ func (f *Processor) rewriteDestination(destination []byte, nodeName string) ([]b
 			link = fmt.Sprintf("%s.html", link)
 		}
 		if _l != link {
-			fmt.Printf("[%s] Rewriting node link for Hugo: %s -> %s \n", nodeName, _l, link)
+			klog.V(6).Infof("[%s] Rewriting node link for Hugo: %s -> %s \n", nodeName, _l, link)
 		}
 		return []byte(link), nil
 	}

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 func newTasksList(tasksCount int, serverURL string, randomizePaths bool) []interface{} {

--- a/pkg/jobs/workqueue_test.go
+++ b/pkg/jobs/workqueue_test.go
@@ -2,16 +2,16 @@ package jobs
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/gardener/docforge/pkg/util/tests"
+	klog "k8s.io/klog/v2"
 )
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 func Test(t *testing.T) {
@@ -24,12 +24,12 @@ func Test(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(5)
 	for i := 0; i < 5; i++ {
-		fmt.Printf("Spawning worker %d\n", i)
+		klog.V(6).Infof("Spawning worker %d\n", i)
 		idx := i
 		go func() {
-			defer fmt.Printf("Worker %d stopped\n", idx)
+			defer klog.V(6).Infof("Worker %d stopped\n", idx)
 			wg.Done()
-			fmt.Printf("Worker %d spawned\n", idx)
+			klog.V(6).Infof("Worker %d spawned\n", idx)
 			var additionalAdded bool
 			for {
 				var (
@@ -38,7 +38,7 @@ func Test(t *testing.T) {
 				if task = wq.Get(); task == nil {
 					return
 				}
-				fmt.Printf("Work done by worker %d %v\n", idx, task)
+				klog.V(6).Infof("Work done by worker %d %v\n", idx, task)
 				if !additionalAdded {
 					wq.Add(struct{}{})
 					additionalAdded = true
@@ -62,14 +62,14 @@ func Test(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			{
-				fmt.Printf("ctx Done received\n")
+				klog.V(6).Infoln("ctx Done received")
 				return
 			}
 		case <-ticker.C:
 			{
 				if wq.(*workQueue).Count() < 1 {
 					if stopped := wq.Stop(); stopped {
-						fmt.Printf("Stopped\n")
+						klog.V(6).Infoln("Stopped")
 						return
 					}
 				}

--- a/pkg/reactor/document_worker.go
+++ b/pkg/reactor/document_worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gardener/docforge/pkg/resourcehandlers"
 	utilnode "github.com/gardener/docforge/pkg/util/node"
 	"github.com/gardener/docforge/pkg/writers"
+	"k8s.io/klog/v2"
 )
 
 // Reader reads the bytes data from a given source URI
@@ -58,7 +59,7 @@ func (w *DocumentWorker) Work(ctx context.Context, task interface{}, wq jobs.Wor
 			for _, content := range task.Node.ContentSelectors {
 				sourceBlob, err := w.Reader.Read(ctx, content.Source)
 				if len(sourceBlob) == 0 {
-					fmt.Printf("No bytes read from source %s\n", content.Source)
+					klog.V(4).Infoln("No bytes read from source", content.Source)
 					continue
 				}
 				if err != nil {

--- a/pkg/reactor/download_controller.go
+++ b/pkg/reactor/download_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gardener/docforge/pkg/jobs"
 	"github.com/gardener/docforge/pkg/resourcehandlers"
 	"github.com/gardener/docforge/pkg/writers"
+	"k8s.io/klog/v2"
 )
 
 // DownloadTask holds information for source and target of linked document resources
@@ -62,11 +63,11 @@ func NewDownloadController(reader Reader, writer writers.Writer, workersCount in
 	}
 
 	job := &jobs.Job{
-		ID:                "Download",
-		FailFast:          failFast,
-		MaxWorkers:        workersCount,
-		MinWorkers:        workersCount,
-		Queue:             jobs.NewWorkQueue(100),
+		ID:                        "Download",
+		FailFast:                  failFast,
+		MaxWorkers:                workersCount,
+		MinWorkers:                workersCount,
+		Queue:                     jobs.NewWorkQueue(100),
 		IsWorkerExitsOnEmptyQueue: true,
 	}
 	controller := &downloadController{
@@ -80,7 +81,7 @@ func NewDownloadController(reader Reader, writer writers.Writer, workersCount in
 }
 
 func (d *downloadWorker) download(ctx context.Context, dt *DownloadTask) error {
-	fmt.Printf("Downloading %s as %s\n", dt.Source, dt.Target)
+	klog.V(6).Infof("Downloading %s as %s\n", dt.Source, dt.Target)
 	blob, err := d.Reader.Read(ctx, dt.Source)
 	if err != nil {
 		return err

--- a/pkg/reactor/integration_test.go
+++ b/pkg/reactor/integration_test.go
@@ -25,7 +25,7 @@ import (
 var ghToken = flag.String("token", "", "GitHub personal token for authenticating requests")
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 func _TestReactorWithGitHub(t *testing.T) {

--- a/pkg/reactor/localitydomain.go
+++ b/pkg/reactor/localitydomain.go
@@ -1,12 +1,12 @@
 package reactor
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/resourcehandlers"
+	"k8s.io/klog/v2"
 )
 
 // localityDomain contains the entries defining a
@@ -91,7 +91,7 @@ func (ld localityDomain) MatchPathInLocality(link string, rhs resourcehandlers.R
 		// FIXME: this is tmp valid only for github urls
 		if strings.HasPrefix(path, prefix) {
 			if link, err = rh.SetVersion(link, localityDomain.Version); err != nil {
-				fmt.Printf("%v\n", err)
+				klog.Errorf("%v\n", err)
 				return link, false
 			}
 			return link, true
@@ -102,7 +102,7 @@ func (ld localityDomain) MatchPathInLocality(link string, rhs resourcehandlers.R
 		repoPrefix := strings.Join(_s, "/")
 		if strings.HasPrefix(path, repoPrefix) {
 			if link, err = rh.SetVersion(link, localityDomain.Version); err != nil {
-				fmt.Printf("%v\n", err)
+				klog.Errorf("%v\n", err)
 				return link, false
 			}
 		}
@@ -124,7 +124,7 @@ func (ld localityDomain) PathInLocality(link string, rhs resourcehandlers.Regist
 		if !ok {
 			return false
 		}
-		fmt.Printf("Path %s in locality domain %s: %v\n", path, localityDomain, strings.HasPrefix(path, localityDomain.Path))
+		klog.V(6).Infof("Path %s in locality domain %s: %v\n", path, localityDomain, strings.HasPrefix(path, localityDomain.Path))
 		// TODO: locality domain to be constructed from key for comparison
 		return reflect.DeepEqual(localityDomain, &localityDomainValue{
 			version,

--- a/pkg/reactor/reactor.go
+++ b/pkg/reactor/reactor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gardener/docforge/pkg/processors"
+	"k8s.io/klog/v2"
 
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/resourcehandlers"
@@ -83,7 +84,7 @@ func (r *Reactor) Run(ctx context.Context, docStruct *api.Documentation, dryRun 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	fmt.Printf("Building documentation structure\n\n")
+	klog.V(4).Info("Building documentation structure\n\n")
 	if err = r.Build(ctx, docStruct.Root, ld); err != nil {
 		return err
 	}

--- a/pkg/reactor/reactor_test.go
+++ b/pkg/reactor/reactor_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 var (

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 // setup sets up a test HTTP server along with a github.Client that is

--- a/pkg/resourcehandlers/github/integration_test.go
+++ b/pkg/resourcehandlers/github/integration_test.go
@@ -20,7 +20,7 @@ import (
 var ghToken = flag.String("token", "", "GitHub personal token for authenticating requests")
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 func TestResolveNodeSelectorLive(t *testing.T) {

--- a/pkg/resourcehandlers/github/resource_locator_test.go
+++ b/pkg/resourcehandlers/github/resource_locator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 func Test_parse(t *testing.T) {

--- a/pkg/resourcehandlers/resource_handlers_test.go
+++ b/pkg/resourcehandlers/resource_handlers_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	tests.SetGlogV(6)
+	tests.SetKlogV(6)
 }
 
 type TestResourceHandler struct {

--- a/pkg/util/files/file_test.go
+++ b/pkg/util/files/file_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 func init() {
-	tests.SetGlogV(10)
+	tests.SetKlogV(10)
 }
 
 func runFileModify(ctx context.Context, t *testing.T, filePath string, period time.Duration) {

--- a/pkg/util/tests/tests.go
+++ b/pkg/util/tests/tests.go
@@ -19,8 +19,8 @@ func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }
 
-// SetGlogV sets the logging flags when unit tests are run
-func SetGlogV(level int) {
+// SetKlogV sets the logging flags when unit tests are run
+func SetKlogV(level int) {
 	l := strconv.Itoa(level)
 	if f := flag.Lookup("v"); f != nil {
 		f.Value.Set(l)

--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -33,8 +33,7 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 	filePath := filepath.Join(p, name)
 
 	if err := ioutil.WriteFile(filePath, docBlob, 0644); err != nil {
-		fmt.Printf("Error writing %s: %v\n", filepath.Join(f.Root, path, name), err)
-		return err
+		return fmt.Errorf("error writing %s: %v", filepath.Join(f.Root, path, name), err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
We need a leveled logging solution to replace the noisy and rudimentary fmt.Print* based one that we currently have.
klog seems to do the job just fine without any quirks and efforts. This PR introduces it.

**Release note**:

```improvement user
docforge now respects standards go flags such as "v", which allows to control the output of the program. Use --v=2 for quiet builds with minimal output, --v=4 for warnings and important output, and --v=6 for a lot of insight and debugging purposes. See the complete list of flags and their default values with docforge -h
```
