### PR TITLE
spell check

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -68,13 +68,13 @@ func (flags *cmdFlags) Configure(command *cobra.Command) {
 	command.Flags().StringVar(&flags.resourcesPath, "resources-download-path", "/__resources",
 		"Resources download path.")
 	command.Flags().StringVar(&flags.ghOAuthToken, "github-oauth-token", "",
-		"GitHub personal token authorizing reading from GitHub repos.")
+		"GitHub personal token authorizing reading from GitHub repositories.")
 	command.Flags().BoolVar(&flags.failFast, "fail-fast", false,
 		"Fail-fast vs fault tolerant operation.")
 	command.Flags().BoolVar(&flags.markdownFmt, "markdownfmt", true,
 		"Applies formatting rules to source markdown.")
 	command.Flags().BoolVar(&flags.dryRun, "dry-run", false,
-		"Runs the command end-to-end but instead of writing files, it will output the proejcted file/folder hierarchy to the standard output and statistics for the processing of each file.")
+		"Runs the command end-to-end but instead of writing files, it will output the projected file/folder hierarchy to the standard output and statistics for the processing of each file.")
 	command.Flags().BoolVar(&flags.resolve, "resolve", false,
 		"Resolves the documentation structure and prints it to the standard output. The resolution expands nodeSelector constructs into node hierarchies.")
 	command.Flags().IntVar(&flags.minWorkersCount, "min-workers", 10,
@@ -83,7 +83,7 @@ func (flags *cmdFlags) Configure(command *cobra.Command) {
 		"Maximum number of parallel workers.")
 	command.Flags().IntVar(&flags.resourceDownloadWorkersCount, "download-workers", 10,
 		"Number of workers downloading document resources in parallel.")
-	// Disabled unitl "fatal error: concurrent map writes" is fixed
+	// Disabled until "fatal error: concurrent map writes" is fixed
 	// command.Flags().BoolVar(&flags.clientMetering, "metering", false,
 	// 	"Enables client-side networking metering to produce Prometheus compliant series.")
 	command.Flags().BoolVar(&flags.hugo, "hugo", false,
@@ -104,7 +104,7 @@ func NewOptions(f *cmdFlags) *Options {
 	)
 	if len(f.ghOAuthToken) > 0 {
 		tokens = map[string]string{
-			// TODO: Currently only github is passed and hardcoded, because there is no flag format supporitn multiple tokens
+			// TODO: Currently only github is passed and hardcoded, because there is no flag format supporting multiple tokens
 			"github.com": f.ghOAuthToken,
 		}
 	}

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -54,7 +54,7 @@ func NewReactor(ctx context.Context, options *Options) *reactor.Reactor {
 		ResourceDownloadWorkersCount: options.ResourceDownloadWorkersCount,
 		MarkdownFmt:                  options.MarkdownFmt,
 		Processor:                    nil,
-		ResourceHandlers:             initResourceHanlders(ctx, options),
+		ResourceHandlers:             initResourceHandlers(ctx, options),
 		DryRunWriter:                 dryRunWriters,
 		Resolve:                      options.Resolve,
 	}
@@ -97,9 +97,9 @@ func WithHugo(reactorOptions *reactor.Options, o *Options) {
 	reactorOptions.Writer = hugo.NewWriter(hugoOptions)
 }
 
-// initResourceHanlders initializes the resource handler
+// initResourceHandlers initializes the resource handler
 // objects used by reactors
-func initResourceHanlders(ctx context.Context, o *Options) []resourcehandlers.ResourceHandler {
+func initResourceHandlers(ctx context.Context, o *Options) []resourcehandlers.ResourceHandler {
 	rhs := []resourcehandlers.ResourceHandler{}
 	if o.GitHubTokens != nil {
 		if token, ok := o.GitHubTokens["github.com"]; ok {

--- a/pkg/api/nodes.go
+++ b/pkg/api/nodes.go
@@ -143,7 +143,7 @@ func (n *Node) AddStats(s ...*Stat) {
 }
 
 // FindNodeByContentSource traverses up and then all around the
-// tree paths in the node's documentation strcuture, looking for
+// tree paths in the node's documentation structure, looking for
 // a node that has contentSource path nodeContentSource
 func FindNodeByContentSource(nodeContentSource string, node *Node) *Node {
 	if node == nil {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -16,7 +16,7 @@
 package api
 
 // Documentation is a documentation structure that can be serialized and deserialized
-// and parsed into a model supporting the tasks around building a concrete documentaiton
+// and parsed into a model supporting the tasks around building a concrete documentation
 // bundle.
 type Documentation struct {
 	// Root is the root node of this documentation structure
@@ -25,7 +25,7 @@ type Documentation struct {
 	// and the value is a node template. Nodes defined as variables can be resused
 	// by reference throughout the documentation structure to minimise duplicate
 	// node definitions. A reference to a variable is in the format `$variable-name`,
-	// where `varaible-name` is a key in this Variables map structure.
+	// where `variable-name` is a key in this Variables map structure.
 	//
 	// Note: WiP - proposed, not implemented yet.
 	Variables map[string]*Node `yaml:"variables,omitempty"`
@@ -37,7 +37,7 @@ type Documentation struct {
 // Node is a recursive, tree data structure representing documentation model.
 type Node struct {
 	parent *Node
-	// Name is the name of this node. If omited, the name is the resource name from
+	// Name is the name of this node. If omitted, the name is the resource name from
 	// Source as reported by an eligible ResourceHandler's Name() method.
 	// Node with multiple Source entries require name.
 	Name string `yaml:"name,omitempty"`
@@ -54,7 +54,7 @@ type Node struct {
 	// `path[#{semantic-block-selector}]`, where:
 	// - `path` is a valid resource locator for a document.
 	// - `semantic-block-selector`is an expression that selects semantic block
-	//   elements from the document similiar to CSS selectors (Note: WiP - proposed,
+	//   elements from the document similar to CSS selectors (Note: WiP - proposed,
 	//	 not implemented yet.).
 	//
 	// Examples:
@@ -82,9 +82,9 @@ type Node struct {
 	// nodes structure resource paths with `Nodes`.
 	// Note: WiP - proposed, not implemented yet.
 	NodeSelector *NodeSelector `yaml:"nodesSelector,omitempty"`
-	// Properties are a map of arbitary, key-value pairs to model custom,
+	// Properties are a map of arbitrary, key-value pairs to model custom,
 	// untyped node properties. They could be used to instruct specific ResourceHandlers
-	// and the serialization of the Node. For example the properyies member could be
+	// and the serialization of the Node. For example the properties member could be
 	// used to set the front-matter to markdowns for front-matter aware builders such
 	// as Hugo.
 	Properties map[string]interface{} `yaml:"properties,omitempty"`
@@ -186,10 +186,10 @@ type LocalityDomain struct {
 	// - An exact download name mapped to a download resource will be used
 	//   to name that resources when downloaded.
 	// - An expression with substitution variables can be used
-	//   to change the default pattern for generating donwloaded resouce
+	//   to change the default pattern for generating downloaded resource
 	//   names, which is $uuid.
 	//   The supported variables are:
-	//   - $name: the original name of the resouce
+	//   - $name: the original name of the resource
 	//   - $path: the original path of the resource in this domain (may be empty)
 	//   - $uuid: the identifier generated f=or the downloaded resource
 	//   - $ext:  the extension of the original resource (may be "")
@@ -201,7 +201,7 @@ type LocalityDomain struct {
 // to LocalityDomainValues
 type LocalityDomainMap map[string]*LocalityDomainValue
 
-// LocalityDomainValue encapsulates the memebers of a
+// LocalityDomainValue encapsulates the members of a
 // LocalityDomain entry value
 type LocalityDomainValue struct {
 	// Version sets the version of the resources that will

--- a/pkg/jobs/controller.go
+++ b/pkg/jobs/controller.go
@@ -5,13 +5,13 @@ import (
 	"sync"
 )
 
-// Controller is the functional interface of worker controllers for workeque.
+// Controller is the functional interface of worker controllers for work queue.
 // It captures a controller lifecycle from its start (Start), through adding
 // tasks for workers (Enqueue) to its immediate (Shutdown) or gracefull end (Stop).
 type Controller interface {
 	// Start starts a controller that reports errors on errCh and
 	// optionally stopped status on shutdownCh if the channel is provided.
-	// The controller blokcs waiting on tasks in its queue untill
+	// The controller blocks waiting on tasks in its queue until
 	// interrupted by context (ctx) or a Shutdown/Stop function call.
 	Start(ctx context.Context, errCh chan<- error, shutdownCh chan struct{})
 	// Enqueue adds a task to this controller's queue for workers to

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -25,7 +25,7 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-// Job enques assignments for parallel processing and synchronous response
+// Job enqueues assignments for parallel processing and synchronous response
 type Job struct {
 	// ID is job identifier used in log messages
 	ID string
@@ -46,7 +46,7 @@ type Job struct {
 	// IsWorkerExitsOnEmptyQueue controls whether a worker exits right after its Work function is
 	// done and no more tasks are available in the queue, or will loop waiting for more tasks.
 	// Note that this flag does not prevent the worker from block waiting for a task. This
-	// can be interrupted only by the workqueue with a task or stop signal. However, after a taks
+	// can be interrupted only by the workqueue with a task or stop signal. However, after a task
 	// is processed it will be consulted whether to continue or exit before block waiting for
 	// another.
 	IsWorkerExitsOnEmptyQueue bool
@@ -170,7 +170,7 @@ func (j *Job) Dispatch(ctx context.Context, tasks []interface{}) *WorkerError {
 				stoppedWorkersCount++
 				if stoppedWorkersCount == 1 {
 					// at least one worker exited - we are done
-					// Unlock all others waiting to get a taks
+					// Unlock all others waiting to get a task
 					if stopped := j.Queue.Stop(); stopped {
 						// klog.V(6).Infof("Workqueue stopped\n")
 					}
@@ -208,7 +208,7 @@ func (j *Job) Dispatch(ctx context.Context, tasks []interface{}) *WorkerError {
 	return workerError
 }
 
-// blocks waiting untill the required amount of workers are started
+// blocks waiting until the required amount of workers are started
 func (j *Job) startWorkers(ctx context.Context, workersCount int, quitCh chan struct{}) <-chan *WorkerError {
 	var (
 		errcList = make([]<-chan *WorkerError, 0)

--- a/pkg/metrics/net.go
+++ b/pkg/metrics/net.go
@@ -84,7 +84,7 @@ func RegisterClientMetrics(registry prometheus.Registerer) {
 	registry.MustRegister(clientCounter, clclientTLSLatencyVec, clientDNSLatencyVec, clientHistVec, clientInFlightGauge)
 }
 
-// ResetClientMetrics resets the HTTP client metrics. The functin is useful for designing self-contained unit tests
+// ResetClientMetrics resets the HTTP client metrics. The function is useful for designing self-contained unit tests
 // where the count of metrics matters.
 func ResetClientMetrics() {
 	clientCounter.Reset()

--- a/pkg/processors/frontmatter.go
+++ b/pkg/processors/frontmatter.go
@@ -58,7 +58,7 @@ func (f *FrontMatter) Process(documentBlob []byte, node *api.Node) ([]byte, erro
 	// TODO: merge node + doc frontmatter per configurable strategy:
 	// - merge where node frontmatter entries win over document frontmatter
 	// - merge where document frontmatter entries win over node frontmatter
-	// - merge where document frontmatter are merged wiht node frontmatter ignoring duplicates (currently impl.)
+	// - merge where document frontmatter are merged with node frontmatter ignoring duplicates (currently impl.)
 	buf := bytes.NewBuffer([]byte{})
 	if fmBytes != nil {
 		buf.Write(fmBytes)

--- a/pkg/reactor/content_processor.go
+++ b/pkg/reactor/content_processor.go
@@ -305,7 +305,7 @@ func substitute(absLink string, node *api.Node) (ok bool, destination *string, t
 	}
 	if substitutes := node.LinksSubstitutes; substitutes != nil {
 		for substituteK, substituteV := range substitutes {
-			// remove trailing slasshes to avoid inequality only due to that
+			// remove trailing slashes to avoid inequality only due to that
 			l := strings.TrimSuffix(absLink, "/")
 			s := strings.TrimSuffix(substituteK, "/")
 			if s == l {

--- a/pkg/reactor/document_controller.go
+++ b/pkg/reactor/document_controller.go
@@ -5,11 +5,11 @@ import (
 )
 
 // DocumentController is the functional interface for a controller
-// handling tasks for processing enqued documents. It ammends the
+// handling tasks for processing enqueued documents. It amends the
 // jobs.Controller interface with specific methods.
 type DocumentController interface {
 	jobs.Controller
-	// SetDownloadScope sets the scope for respurces considered "local"
+	// SetDownloadScope sets the scope for resources considered "local"
 	// and therefore downloaded and relatively linked
 	SetDownloadScope(scope *localityDomain)
 	// GetDownloadController is accessor for the DownloadController

--- a/pkg/reactor/document_worker.go
+++ b/pkg/reactor/document_worker.go
@@ -40,7 +40,7 @@ type GenericReader struct {
 }
 
 // Read reads from the resource at the source URL delegating the
-// the actual operation to a suitable resource hadler
+// the actual operation to a suitable resource handler
 func (g *GenericReader) Read(ctx context.Context, source string) ([]byte, error) {
 	if handler := g.ResourceHandlers.Get(source); handler != nil {
 		return handler.Read(ctx, source)

--- a/pkg/reactor/download_controller.go
+++ b/pkg/reactor/download_controller.go
@@ -21,12 +21,12 @@ type worker interface {
 	download(ctx context.Context, dt *DownloadTask) error
 }
 
-// DownloadController encapsulates activities for asyncronous
+// DownloadController encapsulates activities for asynchronous
 // and parallel scheduling and download of resources
 type DownloadController interface {
 	jobs.Controller
-	// Schedule is a typesafe wrtapper around Controller#Enqueue
-	// for enquing download tasks
+	// Schedule is a typesafe wrapper around Controller#Enqueue
+	// for enqueuing download tasks
 	Schedule(ctx context.Context, link, resourceName string)
 }
 
@@ -124,7 +124,7 @@ func (c *downloadController) setDownloaded(dt *DownloadTask) {
 	c.downloadedResources[dt.Source] = struct{}{}
 }
 
-// Schedule enqeues and resource link for download
+// Schedule enqueues and resource link for download
 func (c *downloadController) Schedule(ctx context.Context, link, resourceName string) {
 	task := &DownloadTask{
 		Source: link,

--- a/pkg/reactor/localitydomain.go
+++ b/pkg/reactor/localitydomain.go
@@ -28,11 +28,11 @@ type localityDomain struct {
 }
 type mapping map[string]*localityDomainValue
 
-// LocalityDomainValue encapsulates the memebers of a
+// LocalityDomainValue encapsulates the members of a
 // localityDomain entry value
 type localityDomainValue struct {
 	// Version is the version of the resources in this
-	// locality odmain
+	// locality domain
 	Version string
 	// Path defines the scope of this locality domain
 	// and is relative to it
@@ -154,7 +154,7 @@ func (ld localityDomain) MatchPathInLocality(link string, rhs resourcehandlers.R
 			}
 			return link, true
 		}
-		// check if in the same repo and then enforce verions rewrite
+		// check if in the same repo and then enforce versions rewrite
 		_s := strings.Split(prefix, "/")
 		_s = _s[:len(_s)-1]
 		repoPrefix := strings.Join(_s, "/")
@@ -204,7 +204,7 @@ func (ld localityDomain) GetDownloadedResourceName(u *urls.URL) string {
 				err     error
 			)
 			if matched, err = regexp.MatchString(substituteMatcher, k); err != nil {
-				klog.Warningf("download subsitution pattern match %s failed for %s\n", substituteMatcher, k)
+				klog.Warningf("download substitution pattern match %s failed for %s\n", substituteMatcher, k)
 				break
 			}
 			if matched {

--- a/pkg/reactor/reactor.go
+++ b/pkg/reactor/reactor.go
@@ -123,7 +123,7 @@ func (r *Reactor) ResolveStructure(ctx context.Context, node *api.Node) error {
 		if err := handler.ResolveNodeSelector(ctx, node); err != nil {
 			return err
 		}
-		// remove node selctors after resolution
+		// remove node selectors after resolution
 		node.NodeSelector = nil
 	}
 	if len(node.Nodes) > 0 {

--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -126,7 +126,7 @@ func cleanupNodeTree(node *api.Node) {
 
 // Cache is indexes GitHub TreeEntries by website resource URLs as keys,
 // mapping ResourceLocator objects to them.
-// TODO: implement me efficently and for parallel use
+// TODO: implement me efficiently and for parallel use
 type Cache struct {
 	cache map[string]*ResourceLocator
 	mux   sync.Mutex
@@ -211,7 +211,7 @@ func NewResourceHandler(client *github.Client, acceptedHosts []string) resourceh
 //
 // If resolveAPIUrl is true, GitHub API will be queried to populate the API URL for
 // that resource (its SHA cannot be inferred from the url). If it's false the APIUrl
-// property will be nil. In this case ctx can be omited too.
+// property will be nil. In this case ctx can be omitted too.
 func (gh *GitHub) URLToGitHubLocator(ctx context.Context, urlString string, resolveAPIUrl bool) (*ResourceLocator, error) {
 	var (
 		ghRL *ResourceLocator

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -371,7 +371,7 @@ func TestRead(t *testing.T) {
 		defer cancel()
 		client, mux, serverURL, teardown := setup()
 		defer teardown()
-		// rewrite cached url keys host to match the mock sevrer
+		// rewrite cached url keys host to match the mock server
 		for k, v := range c.cache.cache {
 			c.cache.cache[strings.Replace(k, "https://github.com", serverURL, 1)] = v
 		}

--- a/pkg/resourcehandlers/github/resource_locator.go
+++ b/pkg/resourcehandlers/github/resource_locator.go
@@ -63,7 +63,7 @@ type ResourceLocator struct {
 }
 
 // String produces a GitHub website link to a resource from a ResourceLocator.
-// That's the format used to link а GitHub rеsource in the documentatiоn structure and pages.
+// That's the format used to link а GitHub resource in the documentation structure and pages.
 // Example: https://github.com/gardener/gardener/blob/master/docs/README.md
 func (r *ResourceLocator) String() string {
 	if r.Type == Wiki {

--- a/pkg/resourcehandlers/resource_handlers.go
+++ b/pkg/resourcehandlers/resource_handlers.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ResourceHandler does resource specific operations on a type of objects
-// identified by an uri schem that it accepts to handle
+// identified by an uri schema that it accepts to handle
 type ResourceHandler interface {
 	// Accepts manifests if this ResourceHandler can manage the type of resources
 	// identified by the URI scheme of uri.
@@ -43,7 +43,7 @@ type registry struct {
 }
 
 // NewRegistry creates Registry object, optionally loading it with
-// resurceHanbdlers if provided
+// resourceHandlers if provided
 func NewRegistry(resourceHandlers ...ResourceHandler) Registry {
 	r := &registry{
 		handlers: []ResourceHandler{},
@@ -70,8 +70,8 @@ func (r *registry) Get(uri string) ResourceHandler {
 	return nil
 }
 
-// Remove removes a ResourceHandler from regsitry. If no argument is provided
-// themethod will remove all registered ahdnlers
+// Remove removes a ResourceHandler from registry. If no argument is provided
+// the method will remove all registered handlers
 func (r *registry) Remove(resourceHandlers ...ResourceHandler) {
 	if len(resourceHandlers) == 0 {
 		r.handlers = []ResourceHandler{}

--- a/pkg/writers/fswriter_test.go
+++ b/pkg/writers/fswriter_test.go
@@ -58,7 +58,7 @@ func TestWrite(t *testing.T) {
 				b []byte
 			)
 			if b, err = ioutil.ReadFile(fPath); err != nil {
-				t.Errorf("unexppected error opening file %v", err)
+				t.Errorf("unexpected error opening file %v", err)
 			}
 			if !reflect.DeepEqual(b, []byte(tc.wantContent)) {
 				t.Errorf("expected content %v != %v", tc.wantContent, tc.wantContent)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for GitHub wiki pages as sources for markdown. Now nodes can use contentSource sources such as `https://github.com/gardener/documentation/wiki/Architecture.md`. 
**Note** the `.md` extension for the wiki resource. It is important to have it in order to successfully resolve this page to a GitHub raw resource and be able to read its markdown.

**Which issue(s) this PR fixes**:
Ads release notes for https://github.com/gardener/docforge/commit/b945777ea8ae475b4fbaf768430f718c723d0b12

**Special notes for your reviewer**:
This adds just spell check changes mostly in comments and is mostly targeting to add release notes for the commit above which was erroneously added not as a PR.

**Release note**:
```improvement user
Documentation structures can now use GitHub wiki pages for `contentSource` source. The wiki page url has to end with `.md`. Example: `https://github.com/gardener/documentation/wiki/Architecture.md`
```
