### PR TITLE
Strip irrelevant nodes generated by resolved nodeSelector

### DIFF
--- a/pkg/reactor/build_test.go
+++ b/pkg/reactor/build_test.go
@@ -1,0 +1,64 @@
+package reactor
+
+import (
+	"testing"
+
+	"github.com/gardener/docforge/pkg/api"
+	"github.com/gardener/docforge/pkg/resourcehandlers"
+)
+
+func Test_tasks(t *testing.T) {
+	newDoc := createNewDocumentation()
+	type args struct {
+		node  *api.Node
+		tasks []interface{}
+		lds   localityDomain
+	}
+	tests := []struct {
+		name          string
+		args          args
+		expectedTasks []*DocumentWorkTask
+	}{
+		{
+			name: "it creates tasks based on the provided doc",
+			args: args{
+				node:  newDoc.Root,
+				tasks: []interface{}{},
+			},
+			expectedTasks: []*DocumentWorkTask{
+				{
+					Node: newDoc.Root,
+				},
+				{
+					Node: archNode,
+				},
+				{
+					Node: apiRefNode,
+				},
+				{
+					Node: blogNode,
+				},
+				{
+					Node: tasksNode,
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rhs := resourcehandlers.NewRegistry(&FakeResourceHandler{})
+			tasks(tc.args.node, &tc.args.tasks)
+
+			if len(tc.args.tasks) != len(tc.expectedTasks) {
+				t.Errorf("expected number of tasks %d != %d", len(tc.expectedTasks), len(tc.args.tasks))
+			}
+
+			for i, task := range tc.args.tasks {
+				if task.(*DocumentWorkTask).Node.Name != tc.expectedTasks[i].Node.Name {
+					t.Errorf("expected task with Node name %s != %s", task.(*DocumentWorkTask).Node.Name, tc.expectedTasks[i].Node.Name)
+				}
+			}
+			rhs.Remove()
+		})
+	}
+}

--- a/pkg/reactor/reactor_test.go
+++ b/pkg/reactor/reactor_test.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	// "fmt"
 
-	"testing"
-
 	"github.com/gardener/docforge/pkg/api"
-	"github.com/gardener/docforge/pkg/resourcehandlers"
 	"github.com/gardener/docforge/pkg/util/tests"
 )
 
@@ -43,62 +40,6 @@ var (
 		ContentSelectors: []api.ContentSelector{{Source: "https://github.com/org/repo/tree/master/docs/tasks"}},
 	}
 )
-
-func Test_tasks(t *testing.T) {
-	newDoc := createNewDocumentation()
-	type args struct {
-		node  *api.Node
-		tasks []interface{}
-		lds   localityDomain
-	}
-	tests := []struct {
-		name          string
-		args          args
-		expectedTasks []*DocumentWorkTask
-	}{
-		{
-			name: "it creates tasks based on the provided doc",
-			args: args{
-				node:  newDoc.Root,
-				tasks: []interface{}{},
-			},
-			expectedTasks: []*DocumentWorkTask{
-				{
-					Node: newDoc.Root,
-				},
-				{
-					Node: archNode,
-				},
-				{
-					Node: apiRefNode,
-				},
-				{
-					Node: blogNode,
-				},
-				{
-					Node: tasksNode,
-				},
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			rhs := resourcehandlers.NewRegistry(&FakeResourceHandler{})
-			tasks(tc.args.node, &tc.args.tasks)
-
-			if len(tc.args.tasks) != len(tc.expectedTasks) {
-				t.Errorf("expected number of tasks %d != %d", len(tc.expectedTasks), len(tc.args.tasks))
-			}
-
-			for i, task := range tc.args.tasks {
-				if task.(*DocumentWorkTask).Node.Name != tc.expectedTasks[i].Node.Name {
-					t.Errorf("expected task with Node name %s != %s", task.(*DocumentWorkTask).Node.Name, tc.expectedTasks[i].Node.Name)
-				}
-			}
-			rhs.Remove()
-		})
-	}
-}
 
 func createNewDocumentation() *api.Documentation {
 	return &api.Documentation{


### PR DESCRIPTION
**What this PR does / why we need it**:
Documentation structures featuring `nodeSelector`s had some irrelevant, erroneous leftover nodes in the resolved nodes tree.
In particular some nodes can could contain `contentSelector` source that referenced `tree` GitHub object. This happened when a resolved folder contained no markdown, e.g. _images_ or _assets_ folders containing only multimedia files used in markdowns.
In these cases the result was a node with `contentSelector` referencing the folder tree object and no child nodes.
This PR introduces a post build cleanup procedure that force removes all references to tree objects and empty _folder_ nodes.

**Release note**:

```noteworthy user
Fixed the reasons for warning about not being able to read from tree object when nodeSelectors resolve to empty nodes referencing folders.
```