### PR TITLE
single door out for main job loop

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -187,7 +187,6 @@ func (j *Job) Dispatch(ctx context.Context, tasks []interface{}) *WorkerError {
 		case err, ok := <-errCh:
 			{
 				if !ok {
-					loop = false
 					break
 				}
 				if err != nil {
@@ -256,7 +255,7 @@ func mergeErrors(channels ...<-chan *WorkerError) <-chan *WorkerError {
 	errCh := make(chan *WorkerError, len(channels))
 
 	// Start an outputF goroutine for each input channel in channels.  outputF
-	// copies values from ch to errCh until c is closed, then calls wg.Done.
+	// copies values from ch to errCh until ch is closed, then calls wg.Done.
 	outputF := func(ch <-chan *WorkerError) {
 		for err := range ch {
 			errCh <- err


### PR DESCRIPTION
**What this PR does / why we need it**:
The current job wait loop can be exited either by a signal to quit and [after all workers have quit](https://github.com/gardener/docforge/blob/9a7fff23ffc786af5509269c38b0be6db68c3968/pkg/jobs/jobs.go#L178-L185), or when the combined workers [error channel is closed](https://github.com/gardener/docforge/blob/9a7fff23ffc786af5509269c38b0be6db68c3968/pkg/jobs/jobs.go#L189-L192), assuming all workers have [quit by then](https://github.com/gardener/docforge/blob/9a7fff23ffc786af5509269c38b0be6db68c3968/pkg/jobs/jobs.go#L223-L224).

However closing a channel yields signal itself and it may happen that the case waiting on workers error channel may receive the last signal and exit the main loop before the case for quit has finished waiting for workers, which will yield close of the quit channel with any not completely finished workers panicking while [trying to send message](https://github.com/gardener/docforge/blob/9a7fff23ffc786af5509269c38b0be6db68c3968/pkg/jobs/jobs.go#L223) they are done.

```
panic: send on closed channel

goroutine 91 [running]:
github.com/gardener/docforge/pkg/jobs.(*Job).startWorkers.func1.1(0xc0002961e0, 0xc000096900, 0xc0002860a0, 0x3)
	/tmp/build/a94a8fe5/git-gardener_docforge-master_master/pkg/jobs/jobs.go:223 +0x4a
github.com/gardener/docforge/pkg/jobs.(*Job).startWorkers.func1(0xc00028a060, 0xc0002860a0, 0xc000284074, 0x7bc0e0, 0xc000280720, 0x3, 0x7bc2a0, 0xc00028a040, 0xc0002961e0)
	/tmp/build/a94a8fe5/git-gardener_docforge-master_master/pkg/jobs/jobs.go:240 +0x386
created by github.com/gardener/docforge/pkg/jobs.(*Job).startWorkers
	/tmp/build/a94a8fe5/git-gardener_docforge-master_master/pkg/jobs/jobs.go:219 +0x127
```

The change in the PR is to ensure main loop exit only in the quit case, ensuring all workers quit before exiting main loop under any circumstances.

**Release note**:
```noteworthy user
Fixes an occasional `panic: send on closed channel` while finishing a build
```
