### PR TITLE
Git info

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -23,6 +23,7 @@ type cmdFlags struct {
 	markdownFmt                  bool
 	rewriteEmbedded              bool
 	ghOAuthToken                 string
+	ghInfoDestination            string
 	dryRun                       bool
 	resolve                      bool
 	clientMetering               bool
@@ -75,8 +76,10 @@ func (flags *cmdFlags) Configure(command *cobra.Command) {
 		"Resources download path.")
 	command.Flags().StringVar(&flags.ghOAuthToken, "github-oauth-token", "",
 		"GitHub personal token authorizing reading from GitHub repositories.")
+	command.Flags().StringVar(&flags.ghInfoDestination, "github-info-destination", "",
+		"If specified, docforge will download also additional github info for the files from the documentation structure into this destination.")
 	command.Flags().BoolVar(&flags.rewriteEmbedded, "rewrite-embedded-to-raw", true,
-		"Rewrites absolute link destinations for embedded resources (images) to reference embeddable media (e.g. for GitHub - reference to a 'raw' version of an image).")
+		"Rewrites absolute link destinations for embedded resources (images) to reference embedable media (e.g. for GitHub - reference to a 'raw' version of an image).")
 	command.Flags().BoolVar(&flags.failFast, "fail-fast", false,
 		"Fail-fast vs fault tolerant operation.")
 	command.Flags().BoolVar(&flags.markdownFmt, "markdownfmt", true,
@@ -146,6 +149,7 @@ func NewOptions(f *cmdFlags) *Options {
 		Metering:                     metering,
 		DryRunWriter:                 dryRunWriter,
 		Resolve:                      f.resolve,
+		GitHubInfoPath:               f.ghInfoDestination,
 		Hugo:                         hugoOptions,
 	}
 }

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -32,6 +32,7 @@ type Options struct {
 	MarkdownFmt                  bool
 	RewriteEmbedded              bool
 	GitHubTokens                 map[string]string
+	GitHubInfoPath               string
 	Metering                     *Metering
 	DryRunWriter                 io.Writer
 	Resolve                      bool
@@ -71,6 +72,13 @@ func NewReactor(ctx context.Context, options *Options, globalLinksCfg *api.Links
 		}
 		o.ResourceDownloadWriter = &writers.FSWriter{
 			Root: filepath.Join(options.DestinationPath, options.ResourcesPath),
+		}
+	}
+
+	if len(options.GitHubInfoPath) > 0 {
+		o.GitInfoWriter = &writers.FSWriter{
+			Root: filepath.Join(options.DestinationPath, options.GitHubInfoPath),
+			Ext:  "json",
 		}
 	}
 

--- a/pkg/git/types.go
+++ b/pkg/git/types.go
@@ -1,0 +1,14 @@
+package git
+
+import "github.com/google/go-github/v32/github"
+
+const (
+	DateFormat = "2006-01-02 15:04:05"
+)
+
+type GitInfo struct {
+	LastModifiedDate *string        `json:"lastmod,omitempty"`
+	PublishDate      *string        `json:"publishdate,omitempty"`
+	Author           *github.User   `json:"author,omitempty"`
+	Contributors     []*github.User `json:"contributors,omitempty"`
+}

--- a/pkg/reactor/document_worker.go
+++ b/pkg/reactor/document_worker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/jobs"
@@ -26,6 +27,7 @@ type DocumentWorker struct {
 	Reader
 	processors.Processor
 	NodeContentProcessor NodeContentProcessor
+	GitHubInfoController GitInfoController
 }
 
 // DocumentWorkTask implements jobs#Task
@@ -106,6 +108,10 @@ func (w *DocumentWorker) Work(ctx context.Context, task interface{}, wq jobs.Wor
 		path := utilnode.Path(task.Node, "/")
 		if err = w.Writer.Write(task.Node.Name, path, document, task.Node); err != nil {
 			return jobs.NewWorkerError(err, 0)
+		}
+
+		if w.GitHubInfoController != nil && len(document) > 0 {
+			w.GitHubInfoController.WriteGitInfo(ctx, filepath.Join(path, task.Node.Name), task.Node)
 		}
 	}
 	return nil

--- a/pkg/reactor/document_worker_test.go
+++ b/pkg/reactor/document_worker_test.go
@@ -61,14 +61,9 @@ func TestDocumentWorkerWork(t *testing.T) {
 			}, &TestWriter{
 				make(map[string][]byte),
 			}, 1, false, rhRegistry),
-			// localityDomain: &localityDomain{
-			// 	mapping: map[string]*localityDomainValue{},
-			// },
 			resourceHandlers: rhRegistry,
 		},
-		// localityDomain{
-		// 	mapping: map[string]*localityDomainValue{},
-		// },
+		nil,
 	}
 
 	testCases := []struct {

--- a/pkg/reactor/githubinfo_controller.go
+++ b/pkg/reactor/githubinfo_controller.go
@@ -1,0 +1,182 @@
+package reactor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/klog/v2"
+
+	"github.com/gardener/docforge/pkg/api"
+	"github.com/gardener/docforge/pkg/git"
+	"github.com/gardener/docforge/pkg/jobs"
+	"github.com/gardener/docforge/pkg/resourcehandlers"
+	nodeutil "github.com/gardener/docforge/pkg/util/node"
+	"github.com/gardener/docforge/pkg/writers"
+	"github.com/google/go-github/v32/github"
+)
+
+// GitInfoController is the functional interface for manageing Git info
+type GitInfoController interface {
+	jobs.Controller
+	WriteGitInfo(ctx context.Context, documentPath string, node *api.Node)
+}
+
+// GitInfoTask wraps the parameters for WriteGitInfo
+type GitInfoTask struct {
+	Node *api.Node
+}
+
+// gitInfoController implements reactor#DownloadController
+type gitInfoController struct {
+	jobs.Controller
+	job *jobs.Job
+	writers.Writer
+	contributors map[string]*github.User
+}
+
+type gitInfoWorker struct {
+	writers.Writer
+	Reader
+}
+
+type gitInfoReader struct {
+	rhs resourcehandlers.Registry
+}
+
+func (r *gitInfoReader) Read(ctx context.Context, source string) ([]byte, error) {
+	if handler := r.rhs.Get(source); handler != nil {
+		return handler.ReadGitInfo(ctx, source)
+	}
+	return nil, nil
+}
+
+// NewGitInfoController creates Controller object for wokring with GitHub info
+func NewGitInfoController(reader Reader, writer writers.Writer, workersCount int, failFast bool, rhs resourcehandlers.Registry) GitInfoController {
+	if reader == nil {
+		reader = &gitInfoReader{
+			rhs: rhs,
+		}
+	}
+	if writer == nil {
+		panic(fmt.Sprint("Invalid argument: writer is nil"))
+		//writer = &writers.FSWriter{}
+	}
+
+	d := &gitInfoWorker{
+		Reader: reader,
+		Writer: writer,
+	}
+
+	job := &jobs.Job{
+		ID:                        "GitHubInfo",
+		FailFast:                  failFast,
+		MaxWorkers:                workersCount,
+		MinWorkers:                workersCount,
+		Queue:                     jobs.NewWorkQueue(100),
+		IsWorkerExitsOnEmptyQueue: true,
+	}
+	controller := &gitInfoController{
+		Controller:   jobs.NewController(job),
+		job:          job,
+		Writer:       writer,
+		contributors: map[string]*github.User{},
+	}
+	controller.job.Worker = withGitInfoController(d, controller)
+	return controller
+}
+
+func withGitInfoController(gitInfoWorker *gitInfoWorker, ctrl *gitInfoController) jobs.WorkerFunc {
+	return func(ctx context.Context, task interface{}, wq jobs.WorkQueue) *jobs.WorkerError {
+		return gitInfoWorker.Work(ctx, ctrl, task, wq)
+	}
+}
+
+func (d *gitInfoWorker) Work(ctx context.Context, ctrl *gitInfoController, task interface{}, wq jobs.WorkQueue) *jobs.WorkerError {
+	if task, ok := task.(*GitInfoTask); ok {
+		node := task.Node
+		sources := []string{}
+		for _, cs := range node.ContentSelectors {
+			sources = append(sources, cs.Source)
+		}
+		if len(node.Source) > 0 {
+			sources = append(sources, node.Source)
+		}
+		var (
+			b               bytes.Buffer
+			info, infoBytes []byte
+			err             error
+		)
+		for _, s := range sources {
+			if info, err = d.Read(ctx, s); err != nil {
+				return jobs.NewWorkerError(err, 0)
+			}
+			if info != nil {
+				b.Write(info)
+			}
+			if err := ctrl.updateContributors(info); err != nil {
+				return jobs.NewWorkerError(err, 0)
+			}
+		}
+
+		if infoBytes, err = ioutil.ReadAll(&b); err != nil {
+			return jobs.NewWorkerError(err, 0)
+		}
+		if err = d.Write(node.Name, nodeutil.Path(node, "/"), infoBytes, node); err != nil {
+			return jobs.NewWorkerError(err, 0)
+		}
+	}
+	return nil
+}
+
+func (g *gitInfoController) WriteGitInfo(ctx context.Context, documentPath string, node *api.Node) {
+	if !g.Enqueue(ctx, &GitInfoTask{
+		Node: node,
+	}) {
+		klog.Warning("Scheduling git info write failed")
+	}
+}
+
+func (g *gitInfoController) Stop(shutdownCh chan struct{}) {
+	defer g.finalize()
+	// Check and exit immediately if nothing in queue and blocked waiting
+	if g.job.Queue.Count() == 0 {
+		g.Controller.Shutdown()
+	}
+	g.Controller.Stop(shutdownCh)
+}
+
+func (g *gitInfoController) updateContributors(info []byte) error {
+	var contributors []*github.User
+	gitInfo := &git.GitInfo{}
+	if err := json.Unmarshal(info, &gitInfo); err != nil {
+		return err
+	}
+	if gitInfo.Contributors == nil {
+		gitInfo.Contributors = []*github.User{}
+	}
+	if gitInfo.Author != nil {
+		contributors = append(gitInfo.Contributors, gitInfo.Author)
+	}
+	for _, c := range contributors {
+		if len(c.GetEmail()) > 0 {
+			g.contributors[c.GetEmail()] = c
+		}
+	}
+	return nil
+}
+
+func (g *gitInfoController) finalize() {
+	var (
+		blob []byte
+		err  error
+	)
+	if blob, err = json.MarshalIndent(g.contributors, "", "  "); err != nil {
+		klog.Errorf("writing contributors.json failed: %s", err.Error())
+	}
+	if err := g.Writer.Write("contributors", "", blob, nil); err != nil {
+		klog.Errorf("writing contributors.json failed: %s", err.Error())
+	}
+}

--- a/pkg/reactor/reactor_test.go
+++ b/pkg/reactor/reactor_test.go
@@ -66,6 +66,9 @@ func (f *FakeResourceHandler) ResolveNodeSelector(ctx context.Context, node *api
 func (f *FakeResourceHandler) Read(ctx context.Context, uri string) ([]byte, error) {
 	return []byte(uri), nil
 }
+func (f *FakeResourceHandler) ReadGitInfo(ctx context.Context, uri string) ([]byte, error) {
+	return []byte(""), nil
+}
 
 func (f *FakeResourceHandler) Name(uri string) string {
 	return uri

--- a/pkg/resourcehandlers/github/gitinfo.go
+++ b/pkg/resourcehandlers/github/gitinfo.go
@@ -1,0 +1,110 @@
+package github
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/gardener/docforge/pkg/git"
+	"github.com/google/go-github/v32/github"
+)
+
+func transform(commits []*github.RepositoryCommit) *git.GitInfo {
+	gitInfo := &git.GitInfo{}
+	nonInternalCommits := []*github.RepositoryCommit{}
+	// skip internal commits
+	for _, commit := range commits {
+		if !isInternalCommit(commit) {
+			nonInternalCommits = append(nonInternalCommits, commit)
+		}
+	}
+	if len(commits) == 0 {
+		return nil
+	}
+	sort.Slice(nonInternalCommits, func(i, j int) bool {
+		return nonInternalCommits[i].GetCommit().GetCommitter().GetDate().After(nonInternalCommits[j].GetCommit().GetCommitter().GetDate())
+	})
+
+	lastModifiedDate := nonInternalCommits[0].GetCommit().GetCommitter().GetDate().Format(git.DateFormat)
+	gitInfo.LastModifiedDate = &lastModifiedDate
+
+	publishDate := commits[len(nonInternalCommits)-1].GetCommit().GetCommitter().GetDate().Format(git.DateFormat)
+	gitInfo.PublishDate = &publishDate
+
+	if gitInfo.Author = getCommitAuthor(nonInternalCommits[len(nonInternalCommits)-1]); gitInfo.Author == nil {
+		klog.Warningf("cannot get commit author")
+	}
+
+	if len(nonInternalCommits) > 1 {
+		gitInfo.Contributors = []*github.User{}
+		registered := []string{}
+		for _, commit := range nonInternalCommits {
+			var contributor *github.User
+			if contributor = getCommitAuthor(commit); contributor == nil {
+				continue
+			}
+			if contributor.GetType() == "User" && contributor.GetEmail() != gitInfo.Author.GetEmail() && !contains(registered, contributor.GetEmail()) {
+				gitInfo.Contributors = append(gitInfo.Contributors, contributor)
+				registered = append(registered, contributor.GetEmail())
+			}
+		}
+	}
+
+	return gitInfo
+}
+
+func contains(slice []string, s string) bool {
+	for _, _s := range slice {
+		if s == _s {
+			return true
+		}
+	}
+	return false
+}
+
+func marshallGitInfo(gitInfo *git.GitInfo) ([]byte, error) {
+	var (
+		blob []byte
+		err  error
+	)
+	if blob, err = json.MarshalIndent(gitInfo, "", "  "); err != nil {
+		return nil, err
+	}
+	return blob, nil
+}
+
+func isInternalCommit(commit *github.RepositoryCommit) bool {
+	message := commit.GetCommit().GetMessage()
+	email := commit.GetCommitter().GetEmail()
+	return strings.HasPrefix(message, "[int]") ||
+		strings.Contains(message, "[skip ci]") ||
+		strings.HasPrefix(email, "gardener.ci") ||
+		strings.HasPrefix(email, "gardener.opensource")
+}
+
+func mergeAuthors(author *github.User, commitAuthor *github.CommitAuthor) *github.User {
+	if author == nil {
+		author = &github.User{}
+	}
+	if commitAuthor != nil {
+		author.Name = commitAuthor.Name
+		author.Email = commitAuthor.Email
+	}
+	return author
+}
+
+func getCommitAuthor(commit *github.RepositoryCommit) *github.User {
+	var contributor *github.User
+	if contributor = commit.GetAuthor(); contributor != nil && commit.GetCommit().GetAuthor() != nil {
+		contributor = mergeAuthors(contributor, commit.GetCommit().GetAuthor())
+	}
+	if contributor == nil && commit.GetCommit().GetAuthor() != nil {
+		contributor = mergeAuthors(&github.User{}, commit.GetCommit().GetAuthor())
+	}
+	if contributor == nil && commit.GetCommit().GetCommitter() != nil {
+		contributor = mergeAuthors(&github.User{}, commit.GetCommit().GetCommitter())
+	}
+	return contributor
+}

--- a/pkg/resourcehandlers/github/gitinfo_test.go
+++ b/pkg/resourcehandlers/github/gitinfo_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gardener/docforge/pkg/git"
+	"github.com/google/go-github/v32/github"
+)
+
+func TestTransform(t *testing.T) {
+	testCases := []struct {
+		testFileNameIn  string
+		testFileNameOut string
+		want            *git.GitInfo
+	}{
+		{
+			"test_format_00_in.json",
+			"test_format_00_out.json",
+			&git.GitInfo{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			var (
+				blobIn, blobOut, b []byte
+				err                error
+			)
+			if blobIn, err = ioutil.ReadFile(filepath.Join("testdata", tc.testFileNameIn)); err != nil {
+				t.Fatalf(err.Error())
+			}
+			commits := []*github.RepositoryCommit{}
+			if err = json.Unmarshal(blobIn, &commits); err != nil {
+				t.Fatalf(err.Error())
+			}
+			got := transform(commits)
+
+			if blobOut, err = ioutil.ReadFile(filepath.Join("testdata", tc.testFileNameOut)); err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			if b, err = json.MarshalIndent(got, "", "  "); err != nil {
+				t.Fatalf(err.Error())
+			}
+			assert.JSONEq(t, string(blobOut), string(b))
+		})
+	}
+
+}

--- a/pkg/resourcehandlers/github/testdata/test_format_00_in.json
+++ b/pkg/resourcehandlers/github/testdata/test_format_00_in.json
@@ -1,0 +1,160 @@
+[
+  {
+      "sha": "2a97450d964f39ee1b320fecd4c565f83f2590eb",
+      "node_id": "MDY6Q29tbWl0MTEzMDMwODQ1OjJhOTc0NTBkOTY0ZjM5ZWUxYjMyMGZlY2Q0YzU2NWY4M2YyNTkwZWI=",
+      "commit": {
+          "author": {
+              "name": "A B",
+              "email": "a.b@com.c",
+              "date": "2020-06-18T18:40:47Z"
+          },
+          "committer": {
+              "name": "A B",
+              "email": "a.b@com.c",
+              "date": "2020-06-18T18:40:47Z"
+          },
+          "message": "fixed broken blogs links",
+          "tree": {
+              "sha": "edbd390adbc5688000a5e400e3f8f47156cc8f4f",
+              "url": "https://api.github.com/repos/gardener/documentation/git/trees/edbd390adbc5688000a5e400e3f8f47156cc8f4f"
+          },
+          "url": "https://api.github.com/repos/gardener/documentation/git/commits/2a97450d964f39ee1b320fecd4c565f83f2590eb",
+          "comment_count": 0,
+          "verification": {
+              "verified": true,
+              "reason": "valid",
+              "signature": "",
+              "payload": ""
+          }
+      },
+      "url": "https://api.github.com/repos/gardener/documentation/commits/2a97450d964f39ee1b320fecd4c565f83f2590eb",
+      "html_url": "https://github.com/gardener/documentation/commit/2a97450d964f39ee1b320fecd4c565f83f2590eb",
+      "comments_url": "https://api.github.com/repos/gardener/documentation/commits/2a97450d964f39ee1b320fecd4c565f83f2590eb/comments",
+      "author": {
+          "login": "a-b",
+          "id": 52317188,
+          "node_id": "MDQ6VXNlcjUyMzE3MTg4",
+          "avatar_url": "https://avatars0.githubusercontent.com/u/52317188?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/a-b",
+          "html_url": "https://github.com/a-b",
+          "followers_url": "https://api.github.com/users/a-b/followers",
+          "following_url": "https://api.github.com/users/a-b/following{/other_user}",
+          "gists_url": "https://api.github.com/users/a-b/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/a-b/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/a-b/subscriptions",
+          "organizations_url": "https://api.github.com/users/a-b/orgs",
+          "repos_url": "https://api.github.com/users/a-b/repos",
+          "events_url": "https://api.github.com/users/a-b/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/a-b/received_events",
+          "type": "User",
+          "site_admin": false
+      },
+      "committer": {
+          "login": "a-b",
+          "id": 52317188,
+          "node_id": "MDQ6VXNlcjUyMzE3MTg4",
+          "avatar_url": "https://avatars0.githubusercontent.com/u/52317188?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/a-b",
+          "html_url": "https://github.com/a-b",
+          "followers_url": "https://api.github.com/users/a-b/followers",
+          "following_url": "https://api.github.com/users/a-b/following{/other_user}",
+          "gists_url": "https://api.github.com/users/a-b/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/a-b/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/a-b/subscriptions",
+          "organizations_url": "https://api.github.com/users/a-b/orgs",
+          "repos_url": "https://api.github.com/users/a-b/repos",
+          "events_url": "https://api.github.com/users/a-b/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/a-b/received_events",
+          "type": "User",
+          "site_admin": false
+      },
+      "parents": [
+          {
+              "sha": "2b2aeb09b15ff75cce872ca9466aca682149903c",
+              "url": "https://api.github.com/repos/gardener/documentation/commits/2b2aeb09b15ff75cce872ca9466aca682149903c",
+              "html_url": "https://github.com/gardener/documentation/commit/2b2aeb09b15ff75cce872ca9466aca682149903c"
+          }
+      ]
+  },
+  {
+      "sha": "249d67aa6a307aebcf5ee2c4c41c044673a646fa",
+      "node_id": "MDY6Q29tbWl0MTEzMDMwODQ1OjI0OWQ2N2FhNmEzMDdhZWJjZjVlZTJjNGM0MWMwNDQ2NzNhNjQ2ZmE=",
+      "commit": {
+          "author": {
+              "name": "A B",
+              "email": "a.b@com.c",
+              "date": "2020-06-18T15:07:40Z"
+          },
+          "committer": {
+              "name": "A B",
+              "email": "a.b@com.c",
+              "date": "2020-06-18T15:07:40Z"
+          },
+          "message": "follow concepts structure in gardener/docs",
+          "tree": {
+              "sha": "16b0fe8f7d32ac7702db39f75ae053d997b06114",
+              "url": "https://api.github.com/repos/gardener/documentation/git/trees/16b0fe8f7d32ac7702db39f75ae053d997b06114"
+          },
+          "url": "https://api.github.com/repos/gardener/documentation/git/commits/249d67aa6a307aebcf5ee2c4c41c044673a646fa",
+          "comment_count": 0,
+          "verification": {
+              "verified": true,
+              "reason": "valid",
+              "signature": "",
+              "payload": ""
+          }
+      },
+      "url": "https://api.github.com/repos/gardener/documentation/commits/249d67aa6a307aebcf5ee2c4c41c044673a646fa",
+      "html_url": "https://github.com/gardener/documentation/commit/249d67aa6a307aebcf5ee2c4c41c044673a646fa",
+      "comments_url": "https://api.github.com/repos/gardener/documentation/commits/249d67aa6a307aebcf5ee2c4c41c044673a646fa/comments",
+      "author": {
+          "login": "a-b",
+          "id": 52317188,
+          "node_id": "MDQ6VXNlcjUyMzE3MTg4",
+          "avatar_url": "https://avatars0.githubusercontent.com/u/52317188?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/a-b",
+          "html_url": "https://github.com/a-b",
+          "followers_url": "https://api.github.com/users/a-b/followers",
+          "following_url": "https://api.github.com/users/a-b/following{/other_user}",
+          "gists_url": "https://api.github.com/users/a-b/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/a-b/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/a-b/subscriptions",
+          "organizations_url": "https://api.github.com/users/a-b/orgs",
+          "repos_url": "https://api.github.com/users/a-b/repos",
+          "events_url": "https://api.github.com/users/a-b/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/a-b/received_events",
+          "type": "User",
+          "site_admin": false
+      },
+      "committer": {
+          "login": "a-b",
+          "id": 52317188,
+          "node_id": "MDQ6VXNlcjUyMzE3MTg4",
+          "avatar_url": "https://avatars0.githubusercontent.com/u/52317188?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/a-b",
+          "html_url": "https://github.com/a-b",
+          "followers_url": "https://api.github.com/users/a-b/followers",
+          "following_url": "https://api.github.com/users/a-b/following{/other_user}",
+          "gists_url": "https://api.github.com/users/a-b/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/a-b/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/a-b/subscriptions",
+          "organizations_url": "https://api.github.com/users/a-b/orgs",
+          "repos_url": "https://api.github.com/users/a-b/repos",
+          "events_url": "https://api.github.com/users/a-b/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/a-b/received_events",
+          "type": "User",
+          "site_admin": false
+      },
+      "parents": [
+          {
+              "sha": "d98051fbe4c2459dfafb6a346d5ce75c010a82b7",
+              "url": "https://api.github.com/repos/gardener/documentation/commits/d98051fbe4c2459dfafb6a346d5ce75c010a82b7",
+              "html_url": "https://github.com/gardener/documentation/commit/d98051fbe4c2459dfafb6a346d5ce75c010a82b7"
+          }
+      ]
+  }
+]

--- a/pkg/resourcehandlers/github/testdata/test_format_00_out.json
+++ b/pkg/resourcehandlers/github/testdata/test_format_00_out.json
@@ -1,0 +1,26 @@
+{
+    "lastmod": "2020-06-18 18:40:47",
+    "publishdate": "2020-06-18 15:07:40",
+    "author": {
+      "login": "a-b",
+      "id": 52317188,
+      "node_id": "MDQ6VXNlcjUyMzE3MTg4",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/52317188?v=4",
+      "html_url": "https://github.com/a-b",
+      "gravatar_id": "",
+      "name": "A B",
+      "email": "a.b@com.c",
+      "type": "User",
+      "site_admin": false,
+      "url": "https://api.github.com/users/a-b",
+      "events_url": "https://api.github.com/users/a-b/events{/privacy}",
+      "following_url": "https://api.github.com/users/a-b/following{/other_user}",
+      "followers_url": "https://api.github.com/users/a-b/followers",
+      "gists_url": "https://api.github.com/users/a-b/gists{/gist_id}",
+      "organizations_url": "https://api.github.com/users/a-b/orgs",
+      "received_events_url": "https://api.github.com/users/a-b/received_events",
+      "repos_url": "https://api.github.com/users/a-b/repos",
+      "starred_url": "https://api.github.com/users/a-b/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/a-b/subscriptions"
+    }
+  }

--- a/pkg/resourcehandlers/resource_handlers.go
+++ b/pkg/resourcehandlers/resource_handlers.go
@@ -18,6 +18,8 @@ type ResourceHandler interface {
 	ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) error
 	// Read a resource content at uri into a byte array
 	Read(ctx context.Context, uri string) ([]byte, error)
+	// Read git info
+	ReadGitInfo(ctx context.Context, uri string) ([]byte, error)
 	// ResourceName returns a breakdown of a resource name in the link, consisting
 	// of name and potentially and extention without the dot.
 	ResourceName(link string) (string, string)

--- a/pkg/resourcehandlers/resource_handlers_test.go
+++ b/pkg/resourcehandlers/resource_handlers_test.go
@@ -26,6 +26,9 @@ func (rh *TestResourceHandler) ResolveNodeSelector(ctx context.Context, node *ap
 func (rh *TestResourceHandler) Read(ctx context.Context, uri string) ([]byte, error) {
 	return nil, nil
 }
+func (rh *TestResourceHandler) ReadGitInfo(ctx context.Context, uri string) ([]byte, error) {
+	return nil, nil
+}
 func (rh *TestResourceHandler) Name(uri string) string {
 	return ""
 }

--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -13,6 +13,7 @@ import (
 // FSWriter is implementation of Writer interface for writing blobs to the file system
 type FSWriter struct {
 	Root string
+	Ext  string
 }
 
 func (f *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) error {
@@ -27,9 +28,14 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 		return err
 	}
 
-	if node != nil && !strings.HasSuffix(name, ".md") {
-		name = fmt.Sprintf("%s.md", name)
+	if len(f.Ext) > 0 {
+		name = fmt.Sprintf("%s.%s", name, f.Ext)
+	} else {
+		if node != nil && !strings.HasSuffix(name, ".md") {
+			name = fmt.Sprintf("%s.md", name)
+		}
 	}
+
 	filePath := filepath.Join(p, name)
 
 	if err := ioutil.WriteFile(filePath, docBlob, 0644); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #56

**Release note**:
```improvement user
An optional `--github-info-destination` flag is available now to specify a destination and require the git commits history for the  content sources of the structure's document nodes to be written to it. Applies only to document nodes from the structure. 
```
```noteworthy user
The default value for `--resources-download-path` flag now is `__resources`
```
