### PR TITLE
fix filesystem resourcehanlder's BuildAbsLink

### DIFF
--- a/pkg/resourcehandlers/fs/fs.go
+++ b/pkg/resourcehandlers/fs/fs.go
@@ -164,7 +164,8 @@ func (fs *fsHandler) BuildAbsLink(source, link string) (string, error) {
 	if filepath.IsAbs(link) {
 		return link, nil
 	}
-	p := filepath.Join(source, link)
+	dir, _ := filepath.Split(source)
+	p := filepath.Join(dir, link)
 	p = filepath.Clean(p)
 	if filepath.IsAbs(p) {
 		return p, nil

--- a/pkg/resourcehandlers/fs/fs_test.go
+++ b/pkg/resourcehandlers/fs/fs_test.go
@@ -88,3 +88,57 @@ func TestResolveNodeSelector(t *testing.T) {
 	}
 	assert.Equal(t, expected, node)
 }
+
+func TestBuildAbsLink(t *testing.T) {
+	testCases := []struct {
+		source   string
+		link     string
+		wantLink string
+		wantErr  error
+	}{
+		{
+			source:   "a/b/c.md",
+			link:     "/d/e/f.md",
+			wantLink: "/d/e/f.md",
+		},
+		{
+			source:   "a/b/c.md",
+			link:     "./d.md",
+			wantLink: "a/b/d.md",
+		},
+		{
+			source:   "a/b/c.md",
+			link:     "d.md",
+			wantLink: "a/b/d.md",
+		},
+		{
+			source:   "a/b/c.md",
+			link:     "../d.md",
+			wantLink: "a/d.md",
+		},
+		{
+			source:   "a/b/c.md",
+			link:     "d/e/f.md",
+			wantLink: "a/b/d/e/f.md",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			fs := fsHandler{}
+			var wantLink string
+			if !filepath.IsAbs(tc.link) {
+				absPath, _ := filepath.Abs(".")
+				wantLink = filepath.Join(absPath, tc.wantLink)
+			} else {
+				wantLink = tc.wantLink
+			}
+			gotLink, gotErr := fs.BuildAbsLink(tc.source, tc.link)
+			if tc.wantErr != nil {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Nil(t, gotErr)
+			}
+			assert.Equal(t, wantLink, gotLink)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue in file system where resource handler  resolving links to absolute incorrectly.

**Which issue(s) this PR fixes**:
Fixes #67 
