### PR TITLE
Command for generating command reference documentation

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -59,6 +59,8 @@ func NewCommand(ctx context.Context, cancel context.CancelFunc) *cobra.Command {
 
 	completion := NewCompletionCmd()
 	cmd.AddCommand(completion)
+	genCmdDocs := NewGenCmdDocs()
+	cmd.AddCommand(genCmdDocs)
 
 	klog.InitFlags(nil)
 	AddFlags(cmd)

--- a/cmd/app/gendocs.go
+++ b/cmd/app/gendocs.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"k8s.io/klog/v2"
+)
+
+const (
+	genDocsMarkdown genDocsFormat = iota
+	genDocsManPages
+)
+
+type genDocsCmdFlags struct {
+	format      string
+	destination string
+}
+
+type genDocsFormat int
+
+func newGenDocsFormat(formatString string) (genDocsFormat, error) {
+	switch formatString {
+	case "md":
+		return genDocsMarkdown, nil
+	case "man":
+		return genDocsManPages, nil
+	}
+	return 0, fmt.Errorf("Unknown format '%s'. Must be one of %v", formatString, []string{"md", "man"})
+}
+
+// NewGenCmdDocs generates commands reference documentation
+// in markdown format
+func NewGenCmdDocs() *cobra.Command {
+	flags := &genDocsCmdFlags{}
+	command := &cobra.Command{
+		Use:   "gen-cmd-docs",
+		Short: "Generates commands reference documentation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := cmd.Root()
+			c.DisableAutoGenTag = true
+			destination := filepath.Clean(flags.destination)
+			if _, err := os.Stat(destination); err != nil {
+				if os.IsNotExist(err) {
+					if err := os.MkdirAll(destination, os.ModePerm); err != nil {
+						klog.Error(err)
+						return err
+					}
+				} else {
+					klog.Error(err)
+					return err
+				}
+			}
+			format, err := newGenDocsFormat(flags.format)
+			if err != nil {
+				klog.Error(err)
+				return err
+			}
+			switch format {
+			case genDocsManPages:
+				{
+					header := &doc.GenManHeader{
+						Title:   "DOCFORGE",
+						Manual:  "Docforge Command Reference",
+						Section: "1",
+					}
+					if err := doc.GenManTree(c, header, destination); err != nil {
+						klog.Fatal(err)
+					}
+				}
+			default:
+				{
+					if err := doc.GenMarkdownTree(c, destination); err != nil {
+						klog.Fatal(err)
+					}
+				}
+			}
+			return nil
+		},
+	}
+	command.Flags().StringVarP(&flags.format, "format", "f", "md",
+		"Specifies the generated documentation format. Must be one of: `md` (for markdown) or `man` (for man pages).")
+	command.Flags().StringVarP(&flags.destination, "destination", "d", "",
+		"Path to directory where the documentation will be generated. If it does not exist, it will be created. Required flag.")
+	command.MarkFlagRequired("destination")
+	return command
+}

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -220,9 +221,11 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=


### PR DESCRIPTION
**What this PR does / why we need it**:
Command reference documentation completes the documentation artifacts for a command-line tool. As the tool itself evolves and flags and commands might change it's a good idea to have an automated way to generate adequate and up-to-date commands reference documentation with each release. Users who would want to integrate docforge and its documentation or want to publish it, or simply prefer to read from documentation material than shell would also benefit.

This PR introduces a command for generating docforge commands reference documentation in two alternative formats - markdown (default) and man pages (for convenience for users addicted to the format).

A natural next step would be to integrate into docforge build and have the latest command reference documentation generated with the a built docforge binary using the new command. In this way each docforge release will have up-to-date commands reference documentation.

**Release note**:

```improvement user
New `gen-cmd-docs --destination --format` command generating docforge  commands reference documentation. Supported formats are Markdown (default, `-f md`) and Man pages (`-f man`). Details how to use are available with `docforge gen-cmd-docs -h`.
```
