### PR TITLE
Manual and automated PR/head-update/release compliance check

### DIFF
--- a/.ci/compliance
+++ b/.ci/compliance
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
+
+if [[ -z "${SOURCE_PATH}" ]]; then
+  SOURCE_PATH="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+fi
+
+cd $SOURCE_PATH
+reuse lint

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,6 +24,8 @@ docforge:
     steps:
       check:
         image: "golang:1.14.4"
+      compliance:
+        image: "fsfe/reuse:latest"       
       test:
         image: "golang:1.14.4"
       build:

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,12 +4,11 @@ Upstream-Contact: The Gardener project <gardener@googlegroups.com>
 Source: https://github.com/gardener/docforge
 
 # --------------------------------------------------
-# source code
+# examples and supplementary
 
 Files:
+  example/*
   .github/*
-  example/hugo/layouts/_default/*
-  example/hugo/layouts/partials/*
   *.json
   .dockerignore
   .gitignore

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,7 @@ test-cov:
 test-clean:
 	@find . -name "*.coverprofile" -type f -delete
 	@rm -f docforge.coverage.html
+
+.PHONY: check-compliance
+check-compliance:
+	@hack/check-compliance

--- a/hack/check-compliance
+++ b/hack/check-compliance
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
+
+if [[ -z "${SOURCE_PATH}" ]]; then
+  SOURCE_PATH="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+fi
+
+docker run -v ${SOURCE_PATH}:/data fsfe/reuse:latest lint


### PR DESCRIPTION
**What this PR does / why we need it**:
Automated and easy manual compliance control. Uses docker image of the `reuse` tool.

**Test manually compliance**:  `make check-compliance <file-paths>`
**CI/CD integration**: same script is integrated in the ci/cd `check` step and transitively in all jobs

excluding files: .reuse/dep5

@swilen-iwanow: Please, check the release job in the pipeline definition
