### PR TITLE
Manifests as Go templates

### DIFF
--- a/cmd/app/config.go
+++ b/cmd/app/config.go
@@ -5,23 +5,44 @@
 package app
 
 import (
+	"bytes"
 	"fmt"
+	"html/template"
 	"io/ioutil"
 
 	"github.com/gardener/docforge/pkg/api"
 )
 
 // Manifest creates documentation model from configration file
-func Manifest(filePath string) *api.Documentation {
+func Manifest(filePath string, vars map[string]string) *api.Documentation {
 	var (
 		docs *api.Documentation
 	)
-	configBytes, err := ioutil.ReadFile(filePath)
+	blob, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		panic(fmt.Sprintf("%v\n", err))
 	}
-	if docs, err = api.Parse(configBytes); err != nil {
+	blob, err = resolveVariables(blob, vars)
+	if err != nil {
+		panic(fmt.Sprintf("%v\n", err))
+	}
+	if docs, err = api.Parse(blob); err != nil {
 		panic(fmt.Sprintf("%v\n", err))
 	}
 	return docs
+}
+
+func resolveVariables(manifestContent []byte, vars map[string]string) ([]byte, error) {
+	var (
+		tmpl *template.Template
+		err  error
+		b    bytes.Buffer
+	)
+	if tmpl, err = template.New("").Parse(string(manifestContent)); err != nil {
+		return nil, err
+	}
+	if err := tmpl.Execute(&b, vars); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Parameterized manifests help significantly reduce redundancy and with that error proneness and make automation easier.
With this PR, we start processing the manifest files as [Go templates](https://golang.org/pkg/text/template/) before starting the docs forging process.

This actually opens up for far more than using variables in the manifest. Now it can be dynamically constructed and scripted to a great extent. 

The variables supplied to the manifest template are provided with a `"string-name=string-value"` map flag `--variables`. The limitations and inconvenience of supplying more complex structure as variables via the CLI flags is the only limitation here. As soon as we provide a config file alternative this will be no longer a constraint. Another option would be to provide a flag that references a YAML file for variables. Neither of these is subject of this PR nut rather a follow-up enhancement step.

**Which issue(s) this PR fixes**:
Fixes #46 

**Special notes for your reviewer**:
Provided that there are a manifest `one.yaml` and a source markdown `a.md` in directory `example`,
and given that `one.yaml` is:
```yaml
structure:
  - source: {{ .path }} 
```
, running: `docforge -d /tmp/docforge-docs -f example/one.yaml --variables="path=example/a.md"`
should replicate `a.md` to `/tmp/docforge-docs/a.md`

**Release note**:
```noteworthy user
Manifest files can now be designed as [Go templates](https://golang.org/pkg/text/template/) to make use of variables iterators and Go as a templating language. Manifests are resolved as templates **before** the forging process and supplied with variables provided as "string-name=string-value" map (with ',' delimiter) argument to the new `--variables` flag. The supported variables values are strings for the moment. Example use in template: `{{ .gardener-version }}` will render to `v1.12.1` with the flag `--variables="gardener-version=v1.12.1"`
```
