### PR TITLE
fix md link text and destination updates

### DIFF
--- a/pkg/markdown/links.go
+++ b/pkg/markdown/links.go
@@ -89,13 +89,13 @@ func updateLink(link parser.Link, destination, text, title []byte) {
 		link.Remove(text != nil && len(text) > 0)
 		return
 	}
-	if text != nil && bytes.Equal(link.GetText(), text) {
+	if text != nil && !bytes.Equal(link.GetText(), text) {
 		link.SetText(text)
 	}
 	if destination != nil && !bytes.Equal(link.GetDestination(), destination) {
 		link.SetDestination(destination)
 	}
-	if title != nil && bytes.Equal(link.GetTitle(), title) {
+	if title != nil && !bytes.Equal(link.GetTitle(), title) {
 		link.SetTitle(title)
 	}
 }

--- a/pkg/markdown/links_test.go
+++ b/pkg/markdown/links_test.go
@@ -4,208 +4,61 @@
 
 package markdown
 
-// func TestRemoveLink(t *testing.T) {
-// 	testCases := []struct {
-// 		in              string
-// 		wantLinksCount  int
-// 		wantImagesCount int
-// 		wantTexts       []string
-// 	}{
-// 		{
-// 			`A [a0](b.md) [a1](b.md "c") ![](a.png) B`,
-// 			0, 0,
-// 			[]string{"A a0", " a1", " ", " B"},
-// 		},
-// 	}
-// 	for _, tc := range testCases {
-// 		t.Run("", func(t *testing.T) {
-// 			mdParser := parser.NewWithExtensions(extensions)
-// 			document := markdown.Parse([]byte(tc.in), mdParser)
-// 			ast.WalkFunc(document, func(node ast.Node, entering bool) ast.WalkStatus {
-// 				if entering {
-// 					if l, ok := node.(*ast.Link); ok {
-// 						removeDestination(l)
-// 					}
-// 					if l, ok := node.(*ast.Image); ok {
-// 						removeDestination(l)
-// 					}
-// 				}
-// 				return ast.GoToNext
-// 			})
-// 			var (
-// 				links, images int
-// 				texts         = make([]string, 0)
-// 			)
-// 			ast.WalkFunc(document, func(node ast.Node, entering bool) ast.WalkStatus {
-// 				if entering {
-// 					if _, ok := node.(*ast.Link); ok {
-// 						links++
-// 					}
-// 					if _, ok := node.(*ast.Image); ok {
-// 						images++
-// 					}
-// 					if t, ok := node.(*ast.text); ok {
-// 						texts = append(texts, string(t.Literal))
-// 					}
-// 				}
-// 				return ast.GoToNext
-// 			})
-// 			assert.Equal(t, tc.wantLinksCount, links)
-// 			assert.Equal(t, tc.wantLinksCount, images)
-// 			assert.Equal(t, tc.wantTexts, texts)
-// 		})
-// 	}
-// }
+import (
+	"testing"
 
-// func TestSetText(t *testing.T) {
-// 	testCases := []struct {
-// 		in                    string
-// 		text                  string
-// 		wantTextsUpdatesCount int
-// 	}{
-// 		{
-// 			`A [a0](b.md) [a1](b.md "c") ![](a.png) B`,
-// 			"b",
-// 			3,
-// 		},
-// 		{
-// 			`A [a0](b.md) [a1](b.md "c") ![](a.png) B`,
-// 			"",
-// 			3,
-// 		},
-// 	}
-// 	for _, tc := range testCases {
-// 		t.Run("", func(t *testing.T) {
-// 			mdParser := parser.NewWithExtensions(extensions)
-// 			document := markdown.Parse([]byte(tc.in), mdParser)
-// 			ast.WalkFunc(document, func(node ast.Node, entering bool) ast.WalkStatus {
-// 				if entering {
-// 					if l, ok := node.(*ast.Link); ok {
-// 						setText(l, []byte(tc.text))
-// 					}
-// 					if i, ok := node.(*ast.Image); ok {
-// 						setText(i, []byte(tc.text))
-// 					}
-// 				}
-// 				return ast.GoToNext
-// 			})
-// 			var (
-// 				textsUpdatesCount int
-// 			)
-// 			ast.WalkFunc(document, func(node ast.Node, entering bool) ast.WalkStatus {
-// 				if entering {
-// 					if l, ok := node.(*ast.Link); ok {
-// 						if bytes.Equal(l.Children[0].AsLeaf().Literal, []byte(tc.text)) {
-// 							textsUpdatesCount++
-// 						}
-// 					}
-// 					if i, ok := node.(*ast.Image); ok {
-// 						if bytes.Equal(i.Children[0].AsLeaf().Literal, []byte(tc.text)) {
-// 							textsUpdatesCount++
-// 						}
-// 					}
-// 				}
-// 				return ast.GoToNext
-// 			})
-// 			assert.Equal(t, tc.wantTextsUpdatesCount, textsUpdatesCount)
-// 		})
-// 	}
-// }
+	"github.com/stretchr/testify/assert"
+)
 
-// //TODO: improve the test results checking
-// func TestUpdateLink(t *testing.T) {
-// 	testCases := []struct {
-// 		in                         string
-// 		destination                []byte
-// 		text                       []byte
-// 		title                      []byte
-// 		wantLinkTextUpdates        []string
-// 		wantLinkDestinationUpdates []string
-// 		wantLinkTitleUpdates       []string
-// 		wantLinkUpdatesCount       int
-// 		wantImageUpdatesCount      int
-// 	}{
-// 		{
-// 			`A [a0](b.md) [a1](b.md "c") ![](a.png) B`,
-// 			[]byte("b"),
-// 			[]byte("new"),
-// 			nil,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			2,
-// 			1,
-// 		},
-// 		{
-// 			`A [a0](b.md) [a1](b.md "c") ![](a.png) B`,
-// 			nil,
-// 			[]byte(""),
-// 			nil,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			0,
-// 			0,
-// 		},
-// 		{
-// 			`A [a0](b.md) [a1](b.md "c") ![](a.png) B`,
-// 			nil,
-// 			[]byte("A"),
-// 			nil,
-// 			nil,
-// 			nil,
-// 			nil,
-// 			0,
-// 			0,
-// 		},
-// 	}
-// 	for _, tc := range testCases {
-// 		t.Run("", func(t *testing.T) {
-// 			mdParser := parser.NewWithExtensions(extensions)
-// 			document := markdown.Parse([]byte(tc.in), mdParser)
-// 			ast.WalkFunc(document, func(node ast.Node, entering bool) ast.WalkStatus {
-// 				if entering {
-// 					if l, ok := node.(*ast.Link); ok {
-// 						updateLink(l, tc.destination, tc.text, tc.title)
-// 					}
-// 					if i, ok := node.(*ast.Image); ok {
-// 						updateLink(i, tc.destination, tc.text, tc.title)
-// 					}
-// 				}
-// 				return ast.GoToNext
-// 			})
-// 			var (
-// 				linkUpdatesCount  int
-// 				imageUpdatesCount int
-// 			)
-// 			ast.WalkFunc(document, func(node ast.Node, entering bool) ast.WalkStatus {
-// 				if entering {
-// 					if l, ok := node.(*ast.Link); ok {
-// 						text := l.Children[0].AsLeaf().Literal
-// 						destination := l.destination
-// 						title := l.Title
-// 						if bytes.Equal(text, tc.text) || bytes.Equal(destination, tc.destination) || bytes.Equal(title, tc.title) {
-// 							linkUpdatesCount++
-// 						}
-// 					}
-// 					if i, ok := node.(*ast.Image); ok {
-// 						text := i.Children[0].AsLeaf().Literal
-// 						destination := i.destination
-// 						title := i.Title
-// 						if bytes.Equal(text, tc.text) || bytes.Equal(destination, tc.destination) || bytes.Equal(title, tc.title) {
-// 							imageUpdatesCount++
-// 						}
-// 					}
-// 				}
-// 				return ast.GoToNext
-// 			})
-// 			assert.Equal(t, tc.wantLinkUpdatesCount, linkUpdatesCount, "link updates")
-// 			assert.Equal(t, tc.wantImageUpdatesCount, imageUpdatesCount, "image updates")
-// 		})
-// 	}
-// }
-
-// func TestParseLinks(t *testing.T) {
-// 	p := NewParser()
-// 	p.parse(&ast.Container{}, []byte("  [a](b.com)"))
-// }
+func TestUpdateLinkRefs(t *testing.T) {
+	testCases := []struct {
+		in       []byte
+		cb       OnLink
+		wantBlob []byte
+		wantErr  error
+	}{
+		{
+			[]byte(`[abc](https://abc.xyz/a/b/c.md)`),
+			func(markdownType Type, destination, text, title []byte) ([]byte, []byte, []byte, error) {
+				return []byte("https://abc.xyz/a/b/c/d/e/f/g.md"), []byte("abcdefg"), nil, nil
+			},
+			[]byte(`[abcdefg](https://abc.xyz/a/b/c/d/e/f/g.md)`),
+			nil,
+		},
+		{
+			[]byte(`[abcdefg](https://abc.xyz/a/b/c/d/e/f/g.md)`),
+			func(markdownType Type, destination, text, title []byte) ([]byte, []byte, []byte, error) {
+				return []byte("https://abc.xyz/a/b/c.md"), []byte("abc"), nil, nil
+			},
+			[]byte(`[abc](https://abc.xyz/a/b/c.md)`),
+			nil,
+		},
+		{
+			[]byte(`[abc](https://abc.xyz/a/b/c.md)`),
+			func(markdownType Type, destination, text, title []byte) ([]byte, []byte, []byte, error) {
+				return []byte("https://abc.xyz/a/b/c.md"), []byte("abc"), nil, nil
+			},
+			[]byte(`[abc](https://abc.xyz/a/b/c.md)`),
+			nil,
+		},
+		{
+			[]byte(`[abc](https://abc.xyz/a/b/c.md)`),
+			func(markdownType Type, destination, text, title []byte) ([]byte, []byte, []byte, error) {
+				return []byte("https://abc.xyz/a/b/d.md"), []byte("abd"), nil, nil
+			},
+			[]byte(`[abd](https://abc.xyz/a/b/d.md)`),
+			nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			gotBlob, gotErr := UpdateLinkRefs([]byte(tc.in), tc.cb)
+			assert.Equal(t, string(tc.wantBlob), string(gotBlob))
+			if tc.wantErr != nil {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Nil(t, gotErr)
+			}
+		})
+	}
+}

--- a/pkg/markdown/parser/links.go
+++ b/pkg/markdown/parser/links.go
@@ -75,6 +75,15 @@ func (l *link) SetText(text []byte) {
 	}
 	offset := len(text) - (l.text.end - l.text.start)
 	l.document.data = replaceBytes(l.document.data, l.text.start, l.text.end, text)
+	// offset next link components, if any
+	if l.destination != nil {
+		l.destination.start = offset + l.destination.start
+		l.destination.end = offset + l.destination.end
+	}
+	if l.title != nil {
+		l.title.start = offset + l.title.start
+		l.title.end = offset + l.title.end
+	}
 	offsetSiblingsByteRanges(l, offset)
 }
 
@@ -91,6 +100,11 @@ func (l *link) SetDestination(text []byte) {
 	}
 	offset := len(text) - (l.destination.end - l.destination.start)
 	l.document.data = replaceBytes(l.document.data, l.destination.start, l.destination.end, text)
+	// offset next link components, if any
+	if l.title != nil {
+		l.title.start = offset + l.title.start
+		l.title.end = offset + l.title.end
+	}
 	offsetSiblingsByteRanges(l, offset)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with missing offset in the _components_ of a markdown link that is changed, similar to how its subsequent siblings are offset.
Fixes an issue with wrong test if original and proposed text/title are different that prevented them to be changed when they were.

**Which issue(s) this PR fixes**:
Fixes #83 
Fixes #84 

**Release note**:
```improvement user
Fixed an issue with failing updates of text and destination components of markdown links when they are longer than the original ones. Updated text in these cases used to overlap the next component(s) because they were not offset with the changed length.
```
```improvement user
Fixed an issue with text or title of markdown links not being updated silently.
```