### PR TITLE
add support for including modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,8 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 // indirect
-	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,7 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -291,8 +292,8 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -325,8 +326,8 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -351,6 +352,7 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc h1:NCy3Ohtk6Iny5V/reW2Ktypo4zIpWBdRJ1uFMjBxdg8=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/api/validate.go
+++ b/pkg/api/validate.go
@@ -17,7 +17,7 @@ func ValidateManifest(manifest *Documentation) error {
 	var errs *multierror.Error
 	if manifest != nil {
 		if manifest.NodeSelector == nil && manifest.Structure == nil {
-			errs = multierror.Append(errs, fmt.Errorf("At least nodeSelector or structure must be present as top-level elements in a manifest"))
+			errs = multierror.Append(errs, fmt.Errorf("At least nodesSelector or structure must be present as top-level elements in a manifest"))
 		}
 		validateNodeSelector(manifest.NodeSelector, errs)
 		if manifest.NodeSelector != nil {

--- a/pkg/reactor/content_processor_test.go
+++ b/pkg/reactor/content_processor_test.go
@@ -477,9 +477,15 @@ type testResourceHandler struct {
 func (rh *testResourceHandler) Accept(uri string) bool {
 	return true
 }
-func (rh *testResourceHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) error {
-	return nil
+
+func (rh *testResourceHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) ([]*api.Node, error) {
+	return nil, nil
 }
+
+func (rh *testResourceHandler) ResolveDocumentation(ctx context.Context, uri string) (*api.Documentation, error) {
+	return nil, nil
+}
+
 func (rh *testResourceHandler) Read(ctx context.Context, uri string) ([]byte, error) {
 	return nil, nil
 }

--- a/pkg/reactor/reactor_test.go
+++ b/pkg/reactor/reactor_test.go
@@ -44,7 +44,7 @@ var (
 func createNewDocumentation() *api.Documentation {
 	return &api.Documentation{
 		Structure: []*api.Node{
-			&api.Node{
+			{
 				Name:             "rootNode",
 				ContentSelectors: []api.ContentSelector{{Source: "https://github.com/org/repo/tree/master/docs"}},
 				Nodes: []*api.Node{
@@ -63,8 +63,12 @@ func (f *FakeResourceHandler) Accept(uri string) bool {
 	return true
 }
 
-func (f *FakeResourceHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) error {
-	return nil
+func (f *FakeResourceHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) ([]*api.Node, error) {
+	return nil, nil
+}
+
+func (f *FakeResourceHandler) ResolveDocumentation(ctx context.Context, uri string) (*api.Documentation, error) {
+	return nil, nil
 }
 
 func (f *FakeResourceHandler) Read(ctx context.Context, uri string) ([]byte, error) {

--- a/pkg/resourcehandlers/fs/fs_test.go
+++ b/pkg/resourcehandlers/fs/fs_test.go
@@ -62,35 +62,41 @@ func TestResolveNodeSelector(t *testing.T) {
 			Path: "testdata",
 		},
 		Nodes: []*api.Node{
-			&api.Node{
+			{
 				Name: "d00",
 				Nodes: []*api.Node{
-					&api.Node{
+					{
 						Name: "d02",
 						Nodes: []*api.Node{
-							&api.Node{
+							{
 								Name:   "f020.md",
 								Source: "testdata/d00/d02/f020.md",
 							},
 						},
 					},
-					&api.Node{
+					{
 						Name:   "f01.md",
 						Source: "testdata/d00/f01.md",
 					},
 				},
 			},
-			&api.Node{
+			{
 				Name:   "f00.md",
 				Source: "testdata/f00.md",
 			},
 		},
 	}
 	expected.SetParentsDownwards()
-	if err = fs.ResolveNodeSelector(nil, node, nil, nil, nil, 0); err != nil {
+	expectedNodes := expected.Nodes
+	for _, n := range expectedNodes {
+		n.SetParent(nil)
+	}
+	nodes, err := fs.ResolveNodeSelector(nil, node, nil, nil, nil, 0)
+	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
-	assert.Equal(t, expected, node)
+
+	assert.Equal(t, expected.Nodes, nodes)
 }
 
 func TestBuildAbsLink(t *testing.T) {

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -267,10 +267,12 @@ func TestResolveNodeSelector(t *testing.T) {
 			c.mux(mux)
 		}
 		gh.Client = client
-		gotError := gh.ResolveNodeSelector(ctx, c.inNode, c.excludePaths, c.frontMatter, c.excludeFrontMatter, c.depth)
+
+		nodes, gotError := gh.ResolveNodeSelector(ctx, c.inNode, c.excludePaths, c.frontMatter, c.excludeFrontMatter, c.depth)
 		if gotError != nil {
 			t.Errorf("error == %q, want %q", gotError, c.wantError)
 		}
+		c.inNode.Nodes = append(c.inNode.Nodes, nodes...)
 		c.want.SetParentsDownwards()
 		api.SortNodesByName(c.inNode)
 		api.SortNodesByName(c.want)

--- a/pkg/resourcehandlers/github/integration_test.go
+++ b/pkg/resourcehandlers/github/integration_test.go
@@ -45,9 +45,11 @@ func TestResolveNodeSelectorLive(t *testing.T) {
 			Path: "https://github.com/gardener/gardener/tree/master/docs",
 		},
 	}
-	if err := gh.ResolveNodeSelector(ctx, node, nil, nil, nil, 0); err != nil {
+	nodes, err := gh.ResolveNodeSelector(ctx, node, nil, nil, nil, 0)
+	if err != nil {
 		fmt.Printf("%v", err)
 	}
+	node.Nodes = nodes
 	b, _ := yaml.Marshal(node)
 	fmt.Println(string(b))
 }

--- a/pkg/resourcehandlers/resource_handlers.go
+++ b/pkg/resourcehandlers/resource_handlers.go
@@ -23,7 +23,7 @@ type ResourceHandler interface {
 	Accept(uri string) bool
 	// ResolveNodeSelector resolves the NodeSelector rules of a Node into subnodes
 	// hierarchy (Node.Nodes)
-	ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) error
+	ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) ([]*api.Node, error)
 	// Read a resource content at uri into a byte array
 	Read(ctx context.Context, uri string) ([]byte, error)
 	// Read git info
@@ -41,6 +41,8 @@ type ResourceHandler interface {
 	// SetVersion sets version to absLink according to the API scheme. For GitHub
 	// for example this would replace e.g. the 'master' segment in the path with version
 	SetVersion(absLink, version string) (string, error)
+	// ResolveDocumentation for a given uri
+	ResolveDocumentation(ctx context.Context, uri string) (*api.Documentation, error)
 }
 
 // Registry can register and return resource handlers

--- a/pkg/resourcehandlers/resource_handlers_test.go
+++ b/pkg/resourcehandlers/resource_handlers_test.go
@@ -24,9 +24,15 @@ type TestResourceHandler struct {
 func (rh *TestResourceHandler) Accept(uri string) bool {
 	return rh.accept
 }
-func (rh *TestResourceHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) error {
-	return nil
+
+func (rh *TestResourceHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) ([]*api.Node, error) {
+	return nil, nil
 }
+
+func (rh *TestResourceHandler) ResolveDocumentation(ctx context.Context, uri string) (*api.Documentation, error) {
+	return nil, nil
+}
+
 func (rh *TestResourceHandler) Read(ctx context.Context, uri string) ([]byte, error) {
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for modularization of the Docforge manifest files. This enables construction of manifests from smaller, potentially reusable manifests, which ultimately lowers the complexity in enormous structures. Modules are imported with a `NodesSelector.Path` referencing a manifest. The manifest can reside on the local file system or at GitHub.
**Which issue(s) this PR fixes**:
Fixes #55 

**Special notes for your reviewer**:
TODOs:
- https://github.com/gardener/docforge/pull/87/files#r518782949 
- https://github.com/gardener/docforge/pull/87/files#r518793265
- https://github.com/gardener/docforge/pull/87#pullrequestreview-525183045
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Support for modules is introduced to minimize the complexity and maximize the agility for Docforge's manifests. Users can now use `nodesSelector` path property to specify a manifest file. The referenced structure nodes and links configuration will be then  merged into the referencing node. 
```
