### PR TITLE
Common html link parser

### DIFF
--- a/pkg/markdown/html_links.go
+++ b/pkg/markdown/html_links.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package markdown
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+var (
+	htmlTagLinkRegex    = regexp.MustCompile(`<\b[^>]*?\b((?i)href|(?i)src)\s*=\s*(\"([^"]*\")|'[^']*'|([^'">\s]+))`)
+	htmlTagLinkURLRegex = regexp.MustCompile(`((http|https|ftp|mailto):\/\/)?(\.?\/?[\w\.\-]+)+\/?([#?=&])?`)
+)
+
+// UpdateHTMLLinkRef is a callback function invoked by UpdateHTMLLinksRefs on
+// each link (src|href attribute) found in an HTML tag.
+// It is supplied the link reference destination and is expected to return
+// a destination that will be used to update the link , if different, or error.
+type UpdateHTMLLinkRef func(destination []byte) ([]byte, error)
+
+// UpdateHTMLLinksRefs matches links in HTML tags in a document content and
+// invokes the supplied updateRef callback function supplying the link
+// reference as argument and using the function call result to update the
+// destination of the matched link.
+func UpdateHTMLLinksRefs(documentBytes []byte, updateRef UpdateHTMLLinkRef) ([]byte, error) {
+	if updateRef == nil {
+		return documentBytes, nil
+	}
+	var errors *multierror.Error
+	documentBytes = htmlTagLinkRegex.ReplaceAllFunc(documentBytes, func(match []byte) []byte {
+		var prefix, suffix string
+		attrs := strings.SplitAfter(string(match), "=")
+		url := attrs[len(attrs)-1]
+		url = htmlTagLinkURLRegex.FindString(url)
+		splits := strings.Split(string(match), url)
+		prefix = splits[0]
+		if len(splits) > 1 {
+			suffix = strings.Split(string(match), url)[1]
+		}
+		destination, err := updateRef([]byte(url))
+		if err != nil {
+			errors = multierror.Append(err)
+			return match
+		}
+		return []byte(fmt.Sprintf("%s%s%s", prefix, destination, suffix))
+	})
+	return documentBytes, errors.ErrorOrNil()
+}

--- a/pkg/markdown/links.go
+++ b/pkg/markdown/links.go
@@ -41,24 +41,24 @@ func NewType(markdownTypeString string) (Type, error) {
 	return 0, fmt.Errorf("Unknown markdown type string '%s'. Must be one of %v", markdownTypeString, []string{"link", "image"})
 }
 
-// OnLink is a callback function invoked on each link
-// by mardown#UpdateLinkRefs
-// It is supplied a link and is expected to return destination,
-// text, title or error.
+// UpdateMarkdownLink is a callback function invoked on each link
+// by mardown#UpdateMarkdownLinks
+// It is supplied link attributes and is expected to return them, potentially
+// updated, or error.
 // A nil destination will yield removing of this link/image markup,
 // leaving only the text component if it's a link
 // Nil text or title returned yield no change. Any other value replaces
 // the original. If a returned title is empty string an originally
 // existing title element will be completely removed
-type OnLink func(markdownType Type, destination, text, title []byte) ([]byte, []byte, []byte, error)
+type UpdateMarkdownLink func(markdownType Type, destination, text, title []byte) ([]byte, []byte, []byte, error)
 
-// UpdateLinkRefs changes document links destinations, consulting
+// UpdateMarkdownLinks changes document links destinations, consulting
 // with callback on the destination to use on each link or image in document.
 // If a callback returns "" for a destination, this is interpreted as
 // request to remove the link destination and leave only the link text or in
 // case it's an image - to remove it completely.
 // TODO: failfast vs fault tolerance support?
-func UpdateLinkRefs(documentBlob []byte, callback OnLink) ([]byte, error) {
+func UpdateMarkdownLinks(documentBlob []byte, callback UpdateMarkdownLink) ([]byte, error) {
 	p := parser.NewParser()
 	document := p.Parse(documentBlob)
 	if callback == nil {

--- a/pkg/markdown/links_test.go
+++ b/pkg/markdown/links_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateLinkRefs(t *testing.T) {
+func TestUpdateMarkdownLinks(t *testing.T) {
 	testCases := []struct {
 		in       []byte
-		cb       OnLink
+		cb       UpdateMarkdownLink
 		wantBlob []byte
 		wantErr  error
 	}{
@@ -52,7 +52,7 @@ func TestUpdateLinkRefs(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			gotBlob, gotErr := UpdateLinkRefs([]byte(tc.in), tc.cb)
+			gotBlob, gotErr := UpdateMarkdownLinks([]byte(tc.in), tc.cb)
 			assert.Equal(t, string(tc.wantBlob), string(gotBlob))
 			if tc.wantErr != nil {
 				assert.Error(t, gotErr)

--- a/pkg/markdown/parser/document.go
+++ b/pkg/markdown/parser/document.go
@@ -9,7 +9,7 @@ type document struct {
 	links []Link
 }
 
-func (d *document) ListLinks(cb OnLinkListed) {
+func (d *document) ListLinks(cb UpdateMarkdownLinkListed) {
 	if cb != nil && d.links != nil {
 		for _, l := range d.links {
 			cb(l)

--- a/pkg/markdown/parser/links_test.go
+++ b/pkg/markdown/parser/links_test.go
@@ -14,7 +14,7 @@ import (
 func TestListLinkRewrites(t *testing.T) {
 	testCases := []struct {
 		in     *document
-		listCb OnLinkListed
+		listCb UpdateMarkdownLinkListed
 		want   []byte
 	}{
 		{

--- a/pkg/markdown/parser/types.go
+++ b/pkg/markdown/parser/types.go
@@ -9,15 +9,15 @@ type Parser interface {
 	Parse(data []byte) Document
 }
 
-// OnLinkListed is a callback function invoked by the
+// UpdateMarkdownLinkListed is a callback function invoked by the
 // ListLinks iterator in Document
-type OnLinkListed func(link Link)
+type UpdateMarkdownLinkListed func(link Link)
 
 // Document is the markdown model parsed from bytes data
 type Document interface {
 	// ListLinks iterates parsed links in this document
 	// and invokes cb on every link
-	ListLinks(cb OnLinkListed)
+	ListLinks(cb UpdateMarkdownLinkListed)
 	// Bytes returns the  parsed document content bytes
 	Bytes() []byte
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The logic for parsing HTML links for rewriting is duplicated in hugo processor and reactor.nodeContentProcessor. This duplication proved hard to maintain. it can an should be generalized similar to handling MD links and that's what this PR does. 

**Which issue(s) this PR fixes**:
Fixes #101 

**Special notes for your reviewer**:
Golang features a builtin HTML parser that does the job of finding links properly. However when it comes back to writing back its renderer does that on best effort and can introduce side-effects as we had with the markdown parsers. On the other hand the regex based solution is missing context on a match (can't tell tag, title, text) and updates are feasible only on the destination component, which we do.    
Perhaps a hybrid solution with traceback for the tag with parser that can give us more context or something in the lines of what we did with the markdown parsers for links is the way to go here. But that will be subject of another PR.

**Release note**:
```improvement user
Fixes an issue with failing parse of HTML links when dockforge is run with `--hugo` flag
```
