### PR TITLE
Silence command usage on errors except those that require it for reference

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -45,6 +45,7 @@ func NewCommand(ctx context.Context, cancel context.CancelFunc) *cobra.Command {
 		Use:   "docforge",
 		Short: "Build documentation bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			options := NewOptions(flags)
 			doc := Manifest(flags.documentationManifestPath, flags.variables)
 			if err := api.ValidateManifest(doc); err != nil {


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #103 

**Release note**:
```noteworthy user
Docforge main command usage is now shown only on flags/cmd/args error.
```
