### PR TITLE
improve the help for cli ref md

### DIFF
--- a/cmd/app/completion.go
+++ b/cmd/app/completion.go
@@ -16,33 +16,33 @@ var completionCmd = &cobra.Command{
 	Short: "Generate completion script",
 	Long: `To load completions:
 
-Bash:
+**Bash**:
 
 $ source <(docforge completion bash)
 
-# To load completions for each session, execute once:
-Linux:
+To load completions for each session, execute once:
+- Linux:
   $ docforge completion bash > /etc/bash_completion.d/docforge
-MacOS:
+- MacOS:
   $ docforge completion bash > /usr/local/etc/bash_completion.d/docforge
 
-Zsh:
+**Zsh**:
 
-# If shell completion is not already enabled in your environment you will need
-# to enable it.  You can execute the following once:
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
 
 $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
-# To load completions for each session, execute once:
+To load completions for each session, execute once:
 $ docforge completion zsh > "${fpath[1]}/_docforge"
 
-# You will need to start a new shell for this setup to take effect.
+You will need to start a new shell for this setup to take effect.
 
-Fish:
+**Fish**:
 
 $ docforge completion fish | source
 
-# To load completions for each session, execute once:
+To load completions for each session, execute once:
 $ docforge completion fish > ~/.config/fish/completions/docforge.fish
 `,
 	DisableFlagsInUseLine: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
The help format of the `docforge completion` is not markdown friendly and the product of `docforge gen-cmd-ref` for it is not very readable. This PR improves that.