### PR TITLE
fix false multiple peer nodes with property index error

### DIFF
--- a/pkg/hugo/fswriter.go
+++ b/pkg/hugo/fswriter.go
@@ -50,7 +50,7 @@ func (w *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 
 		// validate
 		if node.Parent() != nil {
-			if ns := getIndexNodes(node.Parent().Nodes); len(ns) > 0 {
+			if ns := getIndexNodes(node.Parent().Nodes); len(ns) > 1 {
 				names := []string{}
 				for _, n := range ns {
 					names = append(names, n.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
bugfix 

**Which issue(s) this PR fixes**:
Fixes #109

**Release note**:

```improvement user
"Multiple peer nodes with property index: true detected in ..." is no longer thrown when there is 1 or less nodes declaring `index:true` property and building with `--hugo` flag.
```
