### PR TITLE
prepend with manifest dir path every FS uri

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/hugo"
@@ -53,7 +54,7 @@ func NewCommand(ctx context.Context, cancel context.CancelFunc) *cobra.Command {
 				err error
 			)
 			options := NewOptions(flags)
-			if rhs, err = initResourceHandlers(ctx, options.GitHubTokens, options.Metering); err != nil {
+			if rhs, err = initResourceHandlers(ctx, options.GitHubTokens, options.Metering, options.ManifestDir); err != nil {
 				return err
 			}
 			if doc, err = manifest(ctx, flags.documentationManifestPath, rhs, flags.variables); err != nil {
@@ -165,6 +166,7 @@ func NewOptions(f *cmdFlags) *Options {
 		MinWorkersCount:              f.minWorkersCount,
 		ResourceDownloadWorkersCount: f.resourceDownloadWorkersCount,
 		ResourcesPath:                f.resourcesPath,
+		ManifestDir:                  filepath.Dir(f.documentationManifestPath),
 		RewriteEmbedded:              f.rewriteEmbedded,
 		GitHubTokens:                 gatherTokens(f),
 		Metering:                     metering,

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -40,6 +40,7 @@ type Options struct {
 	FailFast                     bool
 	DestinationPath              string
 	ResourcesPath                string
+	ManifestDir                  string
 	ResourceDownloadWorkersCount int
 	RewriteEmbedded              bool
 	GitHubTokens                 map[string]string
@@ -60,7 +61,7 @@ type Metering struct {
 func NewReactor(ctx context.Context, options *Options, globalLinksCfg *api.Links) (*reactor.Reactor, error) {
 	dryRunWriters := writers.NewDryRunWritersFactory(options.DryRunWriter)
 
-	rhs, err := initResourceHandlers(ctx, options.GitHubTokens, options.Metering)
+	rhs, err := initResourceHandlers(ctx, options.GitHubTokens, options.Metering, options.ManifestDir)
 	if err != nil {
 		return nil, err
 	}
@@ -127,9 +128,9 @@ func WithHugo(reactorOptions *reactor.Options, o *Options) {
 
 // initResourceHandlers initializes the resource handler
 // objects used by reactors
-func initResourceHandlers(ctx context.Context, githubTokens map[string]string, metering *Metering) ([]resourcehandlers.ResourceHandler, error) {
+func initResourceHandlers(ctx context.Context, githubTokens map[string]string, metering *Metering, manifestDir string) ([]resourcehandlers.ResourceHandler, error) {
 	rhs := []resourcehandlers.ResourceHandler{
-		fs.NewFSResourceHandler(),
+		fs.NewFSResourceHandler(manifestDir),
 	}
 	var errs *multierror.Error
 	if githubTokens != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Running Docforge against a `Documentation Structure` that imports another `Documentation Structure` using file system ResourceHandler fails if they are not in the current working directory of Docforge. With this PR we calculate the `cwd` of Docforge and calculate the relative paths to the imported `Documentation Structure`  
