### PR TITLE
Do not panic when all git commits are internal

### DIFF
--- a/pkg/reactor/gitinfo_controller.go
+++ b/pkg/reactor/gitinfo_controller.go
@@ -57,7 +57,7 @@ func (r *gitInfoReader) Read(ctx context.Context, source string) ([]byte, error)
 	return nil, nil
 }
 
-// NewGitInfoController creates Controller object for wokring with GitHub info
+// NewGitInfoController creates Controller object for wokring with Git info
 func NewGitInfoController(reader Reader, writer writers.Writer, workersCount int, failFast bool, rhs resourcehandlers.Registry) GitInfoController {
 	if reader == nil {
 		reader = &gitInfoReader{
@@ -75,7 +75,7 @@ func NewGitInfoController(reader Reader, writer writers.Writer, workersCount int
 	}
 
 	job := &jobs.Job{
-		ID:                        "GitHubInfo",
+		ID:                        "GitInfo",
 		FailFast:                  failFast,
 		MaxWorkers:                workersCount,
 		MinWorkers:                workersCount,
@@ -117,9 +117,10 @@ func (d *gitInfoWorker) Work(ctx context.Context, ctrl *gitInfoController, task 
 			if info, err = d.Read(ctx, s); err != nil {
 				return jobs.NewWorkerError(err, 0)
 			}
-			if info != nil {
-				b.Write(info)
+			if info == nil {
+				continue
 			}
+			b.Write(info)
 			if err := ctrl.updateContributors(info); err != nil {
 				return jobs.NewWorkerError(err, 0)
 			}

--- a/pkg/resourcehandlers/fs/fs.go
+++ b/pkg/resourcehandlers/fs/fs.go
@@ -128,7 +128,7 @@ func (fs *fsHandler) ReadGitInfo(ctx context.Context, uri string) ([]byte, error
 	}
 
 	if len(log) == 0 {
-		return []byte(""), nil
+		return nil, nil
 	}
 
 	for _, logEntry := range log {

--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -457,6 +457,9 @@ func (gh *GitHub) ReadGitInfo(ctx context.Context, uri string) ([]byte, error) {
 	}
 	if commits != nil {
 		gitInfo := transform(commits)
+		if gitInfo == nil {
+			return nil, nil
+		}
 		if blob, err = marshallGitInfo(gitInfo); err != nil {
 			return nil, err
 		}

--- a/pkg/resourcehandlers/github/gitinfo.go
+++ b/pkg/resourcehandlers/github/gitinfo.go
@@ -16,6 +16,9 @@ import (
 )
 
 func transform(commits []*github.RepositoryCommit) *git.GitInfo {
+	if commits == nil {
+		return nil
+	}
 	gitInfo := &git.GitInfo{}
 	nonInternalCommits := []*github.RepositoryCommit{}
 	// skip internal commits
@@ -24,7 +27,7 @@ func transform(commits []*github.RepositoryCommit) *git.GitInfo {
 			nonInternalCommits = append(nonInternalCommits, commit)
 		}
 	}
-	if len(commits) == 0 {
+	if len(nonInternalCommits) == 0 {
 		return nil
 	}
 	sort.Slice(nonInternalCommits, func(i, j int) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Bugfix

**Which issue(s) this PR fixes**:
Fixes #114 

**Release note**:
```improvement user
Using docforge with `--github-info-destination` flag failed with nil pointer reference panic when all commits for a file referenced by a node source in the structure were internal. This is fixed now.
```
