### PR TITLE
prevent reduntant frontmatter property: "title"

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -34,8 +34,7 @@ cd ${SOURCE_PATH}
 ###############################################################################
 
 EFFECTIVE_VERSION_FILE="${VERSION_PATH}/version"
-if [[ -f ${EFFECTIVE_VERSION_FILE} ]]
-then
+if [[ -f ${EFFECTIVE_VERSION_FILE} ]]; then
   VERSION_FILE="${EFFECTIVE_VERSION_FILE}"
 else
   VERSION_FILE="$(${READLINK_BIN} -f "${SOURCE_PATH}/VERSION")"
@@ -74,5 +73,6 @@ else
   go build \
     -v \
     -o ${BINARY_PATH}/docforge \
+    -ldflags "-w -X github.com/gardener/docforge/pkg/version.Version=$(git rev-parse HEAD)" \
     cmd/*.go
 fi

--- a/pkg/processors/frontmatter_test.go
+++ b/pkg/processors/frontmatter_test.go
@@ -81,7 +81,6 @@ title: Test1
 			},
 			wantErr: nil,
 			wantDocument: `---
-title: Test1
 title: Test2
 ---
 `,


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the implementation merges frontmatter defined inside the node and the document. 
**Which issue(s) this PR fixes**:
Fixes #116

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
If both document and a node referencing it as source define front-matter, they will be merged and where there are conflicting keys the node front-matter has priority. Note that this is a temporary solution and may change.
```
