### PR TITLE
Fix document not updated after HTML links update

### DIFF
--- a/pkg/reactor/content_processor.go
+++ b/pkg/reactor/content_processor.go
@@ -90,7 +90,7 @@ func (c *nodeContentProcessor) ReconcileLinks(ctx context.Context, node *api.Nod
 	if err != nil {
 		return nil, err
 	}
-	if _, err := c.reconcileHTMLLinks(ctx, node, documentBytes, contentSourcePath); err != nil {
+	if documentBytes, err = c.reconcileHTMLLinks(ctx, node, documentBytes, contentSourcePath); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The document byte array produced after processing HTML links was ignored. This is fixed now.

**Which issue(s) this PR fixes**:
Fixes #118 

**Release note**:
```improvement user
Fixed a problem with HTML links not getting updated to absolute or to downloaded resource references in cases when they needed to.
```
