### PR TITLE
Fix deferred unlock miss

### DIFF
--- a/pkg/reactor/build.go
+++ b/pkg/reactor/build.go
@@ -90,7 +90,7 @@ func (r *Reactor) Build(ctx context.Context, documentationStructure []*api.Node)
 					stoppedControllers++
 					// propagate the stop to the related download controller
 					r.DocController.GetDownloadController().Stop(nil)
-					// propagate the stop to the related download controller
+					// propagate the stop to the related git info controller
 					if r.GitInfoController != nil {
 						r.GitInfoController.Stop(nil)
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Moves the rwLock's `Lock` and deferred `Unlock` to the proper place in the `updateContributors` function.
- Added a few v=6 level logs to have the read/writes related to the github info operations not that silent.
- Early exit for container nodes (sanity check). Git info is gathered only for document nodes.

**Which issue(s) this PR fixes**:
Fixes #123 

**Special notes for your reviewer**:
Bug introduced with gardener/docforge#122

