### PR TITLE
add more context to download logs/errs

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -189,7 +189,7 @@ func gatherTokens(flags *cmdFlags) map[string]string {
 	}
 	if len(flags.ghOAuthToken) > 0 {
 		if _, ok := tokens["github.com"]; ok {
-			klog.Warning("gihtub.com token is overridden by the provided token with `--github-oauth-token flag` ")
+			klog.Warning("github.com token is overridden by the provided token with `--github-oauth-token flag` ")
 		}
 		tokens["github.com"] = flags.ghOAuthToken
 	}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -179,7 +179,7 @@ func (j *Job) Dispatch(ctx context.Context, tasks []interface{}) *WorkerError {
 					break
 				}
 				if err != nil {
-					errors = multierror.Append(err)
+					errors = multierror.Append(errors, err)
 					if j.FailFast {
 						if stopped := j.Queue.Stop(); stopped {
 							// klog.V(6).Infof("Workqueue stopped\n")

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -302,7 +302,7 @@ func TestDispatchError(t *testing.T) {
 	actualError := job.Dispatch(ctx, newTasksList(tasksCount, "", false))
 
 	assert.Error(t, actualError)
-	assert.Equal(t, expectedError, errors.Unwrap((errors.Unwrap(actualError))))
+	assert.True(t, errors.Is(actualError, expectedError))
 	//Did we fail early?
 	actualCallCount := int(atomic.LoadInt32(&worker.faultySenderCallsCount))
 	assert.True(t, actualCallCount < tasksCount)

--- a/pkg/reactor/content_processor_test.go
+++ b/pkg/reactor/content_processor_test.go
@@ -36,7 +36,7 @@ func Test_processLink(t *testing.T) {
 		wantDestination   *string
 		wantText          *string
 		wantTitle         *string
-		wantDownload      *Download
+		wantDownload      *DownloadTask
 		wantErr           error
 		mutate            func(c *nodeContentProcessor)
 	}{
@@ -102,9 +102,11 @@ func Test_processLink(t *testing.T) {
 			wantDestination:   tests.StrPtr("/__resources"),
 			wantText:          nil,
 			wantTitle:         nil,
-			wantDownload: &Download{
-				"https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
-				"",
+			wantDownload: &DownloadTask{
+				Source:    "https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
+				Target:    "",
+				Referer:   "https://github.com/gardener/gardener/blob/v1.10.0/docs/README.md",
+				Reference: "./image.png",
 			},
 			wantErr: nil,
 			mutate: func(c *nodeContentProcessor) {
@@ -156,9 +158,11 @@ func Test_processLink(t *testing.T) {
 			wantDestination:   tests.StrPtr("/__resources"),
 			wantText:          nil,
 			wantTitle:         nil,
-			wantDownload: &Download{
-				"https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
-				"",
+			wantDownload: &DownloadTask{
+				Source:    "https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
+				Target:    "",
+				Referer:   "https://github.com/gardener/gardener/blob/v1.10.0/docs/README.md",
+				Reference: "https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
 			},
 			wantErr: nil,
 			mutate: func(c *nodeContentProcessor) {
@@ -278,9 +282,11 @@ func Test_processLink(t *testing.T) {
 			wantDestination:   tests.StrPtr("/__resources"),
 			wantText:          nil,
 			wantTitle:         nil,
-			wantDownload: &Download{
-				"https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
-				"",
+			wantDownload: &DownloadTask{
+				Source:    "https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
+				Target:    "",
+				Referer:   "https://github.com/gardener/gardener/blob/v1.10.0/docs/README.md",
+				Reference: "https://github.com/gardener/gardener/blob/master/docs/image.png",
 			},
 			wantErr: nil,
 			mutate: func(c *nodeContentProcessor) {
@@ -316,9 +322,11 @@ func Test_processLink(t *testing.T) {
 			wantDestination:   tests.StrPtr("/__resources"),
 			wantText:          tests.StrPtr("Test text"),
 			wantTitle:         tests.StrPtr("Test title"),
-			wantDownload: &Download{
-				"https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
-				"",
+			wantDownload: &DownloadTask{
+				Source:    "https://github.com/gardener/gardener/blob/v1.10.0/docs/image.png",
+				Target:    "",
+				Referer:   "https://github.com/gardener/gardener/blob/v1.10.0/docs/README.md",
+				Reference: "./image.png",
 			},
 			wantErr: nil,
 			mutate: func(c *nodeContentProcessor) {
@@ -356,7 +364,7 @@ func Test_processLink(t *testing.T) {
 			assert.Equal(t, tc.wantErr, gotErr)
 			if gotDownload != nil {
 				if tc.wantDownload != nil {
-					tc.wantDownload.resourceName = gotDownload.resourceName
+					tc.wantDownload.Target = gotDownload.Target
 				}
 			}
 			assert.Equal(t, tc.wantDownload, gotDownload)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Makes sure `resolveLinks` records also referrer and (original) reference and then these are used as additional context when an error occurs
- Now download controller registers not only downloaded sources, but also the tasks that requested that (`source: []*DownloadTask`) and supplies info for all referrers and references that were affected by an error using this.
- the multierror result is less than ideal but formatting is not part of this PR
- Fixes a couple of typos.

Use `-v=6` to test

**Which issue(s) this PR fixes**:
Fixes #125
Fixes #126

**Release note**:
```noteworthy user
Logs for download failures now include more context to trace them back to the reference link and fix it if that is the reason. 
```
```improvement user
Fixed the list of error messages, which used to include only the last error. Now the list includes all recorded errors. Applies to fault-tolerant forge runs.
```
