### PR TITLE
add sanity check for links

### DIFF
--- a/pkg/hugo/processor.go
+++ b/pkg/hugo/processor.go
@@ -45,6 +45,10 @@ func (f *Processor) Process(documentBlob []byte, node *api.Node) ([]byte, error)
 		return nil, err
 	}
 	if documentBlob, err = mdutil.UpdateMarkdownLinks(contentBytes, func(markdownType mdutil.Type, destination, text, title []byte) ([]byte, []byte, []byte, error) {
+		// quick sanity check for ill-parsed links if any
+		if destination == nil {
+			return destination, text, title, nil
+		}
 		return f.rewriteDestination(destination, text, title, node.Name)
 	}); err != nil {
 		return nil, err

--- a/pkg/markdown/html_links.go
+++ b/pkg/markdown/html_links.go
@@ -44,7 +44,7 @@ func UpdateHTMLLinksRefs(documentBytes []byte, updateRef UpdateHTMLLinkRef) ([]b
 		}
 		destination, err := updateRef([]byte(url))
 		if err != nil {
-			errors = multierror.Append(err)
+			errors = multierror.Append(errors, err)
 			return match
 		}
 		return []byte(fmt.Sprintf("%s%s%s", prefix, destination, suffix))


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds sanity check on parsed links before processing them and skips processing if no destination is found
- Fixes incorrect usage for multierror that stored only the last entry in the multierror object

**Which issue(s) this PR fixes**:
Fixes #130 

**Release note**:
```improvement user
Logs had entries like `-> abc`, which were result from text, incorrectly parsed text as links. Such incorrectly parsed links will no longer be processed as links.
```
```improvement user
Fixed reported errors from command execution. Previously many were logged but the few were reported as errors summary report at the end of the command execution.
```
