### PR TITLE
add strings.Split as function in templates

### DIFF
--- a/cmd/app/manifest.go
+++ b/cmd/app/manifest.go
@@ -48,7 +48,9 @@ func resolveVariables(manifestContent []byte, vars map[string]string) ([]byte, e
 		err  error
 		b    bytes.Buffer
 	)
-	if tmpl, err = template.New("").Parse(string(manifestContent)); err != nil {
+	tplFuncMap := make(template.FuncMap)
+	tplFuncMap["Split"] = strings.Split
+	if tmpl, err = template.New("").Funcs(tplFuncMap).Parse(string(manifestContent)); err != nil {
 		return nil, err
 	}
 	if err := tmpl.Execute(&b, vars); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Split as function that could be used in templates to split strings. 
```
{{ result := Split "a,b,c" "," }}
```

result is going to equal to the array result=[a,b,c] 

For more details about Split functions: https://golang.org/pkg/strings/#Split

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
