### PR TITLE
Fixes uses of version segment in github urls

### DIFF
--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -290,8 +290,7 @@ func (gh *GitHub) URLToGitHubLocator(ctx context.Context, urlString string, reso
 			return nil, err
 		}
 		if ghRL.Type != Wiki && resolveAPIUrl {
-			_p := strings.Split(ghRL.Path, "/")[0]
-			if _, found := nonSHAPathPrefixes[_p]; found {
+			if len(ghRL.SHAAlias) == 0 {
 				return ghRL, nil
 			}
 			// grab the index of this repo
@@ -527,11 +526,7 @@ func (gh *GitHub) SetVersion(absLink, version string) (string, error) {
 		return "", err
 	}
 
-	if len(rl.Path) > 0 {
-		pathSegments := strings.Split(rl.Path, "/")
-		if _, found := nonSHAPathPrefixes[pathSegments[0]]; found {
-			return absLink, nil
-		}
+	if len(rl.SHAAlias) > 0 {
 		rl.SHAAlias = version
 		return rl.String(), nil
 	}

--- a/pkg/resourcehandlers/github/resource_locator.go
+++ b/pkg/resourcehandlers/github/resource_locator.go
@@ -74,17 +74,6 @@ const (
 	Commits
 )
 
-var nonSHAPathPrefixes = map[string]struct{}{
-	Releases.String(): {},
-	Issues.String():   {},
-	Issue.String():    {},
-	Pulls.String():    {},
-	Pull.String():     {},
-	Wiki.String():     {},
-	Commit.String():   {},
-	Commits.String():  {},
-}
-
 // ResourceLocator is an abstraction for GitHub specific Universal Resource Locators (URLs)
 // It is an internal structure breaking down the GitHub URLs into more segment types such as
 // Repo, Owner or SHA.


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches to using `ResourceLocator` `SHAAlias` instead of parsing the `Path` property.

**Which issue(s) this PR fixes**:
Fixes #133

**Release note**:
```improvement user
Fix wrong additions of a version segment in url paths that do not have such type of segment, like pulls/wiki etc.
```
