### PR TITLE
Use alpine docker image from gcr.io registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.11.6
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1
 
 COPY bin/rel/docforge-linux-amd64 /usr/local/bin/docforge
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is in order to prevent multiple hits to the Docker's registry rate limits.
