### PR TITLE
Skip parsing invalid links

### DIFF
--- a/pkg/markdown/parser/links_parse.go
+++ b/pkg/markdown/parser/links_parse.go
@@ -383,6 +383,12 @@ func parseLink(p *parser, data []byte, offset int) (int, Link) {
 	// call the relevant rendering function
 	switch t {
 	case linkNormal:
+		if txtE-txtB <= 0 {
+			return i, nil
+		}
+		if linkE-linkB <= 0 {
+			return i, nil
+		}
 		maybeTitle := &bytesRange{
 			start: offset + titleB,
 			end:   offset + titleE,
@@ -426,6 +432,9 @@ func parseLink(p *parser, data []byte, offset int) (int, Link) {
 		return i, link
 
 	case linkImg:
+		if linkE-linkB <= 0 {
+			return i, nil
+		}
 		image := &link{
 			start: start,
 			end:   offset + end,

--- a/pkg/markdown/parser/links_parse_test.go
+++ b/pkg/markdown/parser/links_parse_test.go
@@ -54,17 +54,11 @@ func TestParseLinks(t *testing.T) {
 		// },
 		{
 			`[link]()`,
-			[][]int{
-				[]int{0, 8},
-				[]int{1, 5},
-			},
+			nil,
 		},
 		{
 			`[link](<>)`,
-			[][]int{
-				[]int{0, 10},
-				[]int{1, 5},
-			},
+			nil,
 		},
 		{
 			`[link](</my uri>)`,
@@ -277,9 +271,10 @@ func TestParseLinks(t *testing.T) {
 					}
 				}
 			}
+			var expected Link = want
 			zeroValue := &link{}
 			if *want == *zeroValue {
-				want = nil
+				expected = *new(Link)
 			}
 			s := strings.Split(tc.in, " ")
 			offset := 0
@@ -289,8 +284,10 @@ func TestParseLinks(t *testing.T) {
 				}
 				offset++
 			}
+
 			_, got := parseLink(p.(*parser), []byte(tc.in), offset)
-			if assert.Equal(t, want, got) {
+
+			if assert.Equal(t, expected, got) {
 				if got == nil {
 					fmt.Println("|nil|")
 				} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip early, during parse, links that do not meet minimal criteria for valid links.

**Which issue(s) this PR fixes**:
Fixes #136

