### PR TITLE
fix parsing of links inside code span

### DIFF
--- a/pkg/markdown/parser/autolinks_parse.go
+++ b/pkg/markdown/parser/autolinks_parse.go
@@ -166,6 +166,40 @@ func maybeAutoLink(p *parser, data []byte, offset int) (int, Link) {
 	return 0, nil
 }
 
+func codeSpan(p *parser, data []byte, offset int) (int, Link) {
+	var backtickCount, i, end int
+	data = data[offset:]
+
+	for backtickCount < len(data) && data[backtickCount] == '`' {
+		backtickCount++
+	}
+
+	for end = backtickCount; end < len(data) && i < backtickCount; end++ {
+		if data[end] == '`' {
+			i++
+		} else {
+			i = 0
+		}
+	}
+
+	// no matching delimiter?
+	if i < backtickCount && end >= len(data) {
+		return 0, nil
+	}
+
+	// trim outside whitespace
+	fBegin := backtickCount
+	for fBegin < end && data[fBegin] == ' ' {
+		fBegin++
+	}
+
+	fEnd := end - backtickCount
+	for fEnd > fBegin && data[fEnd-1] == ' ' {
+		fEnd--
+	}
+	return end, nil
+}
+
 func parseAutoLink(p *parser, data []byte, offset int) (int, Link) {
 	// Now a more expensive check to see if we're not inside an anchor element
 	anchorStart := offset

--- a/pkg/markdown/parser/links_parse_test.go
+++ b/pkg/markdown/parser/links_parse_test.go
@@ -190,12 +190,12 @@ func TestParseLinks(t *testing.T) {
 			},
 		},
 		{
-			`  [ a 
+			`  [ a
  ](  b.com)`,
 			[][]int{
-				[]int{2, 18},
+				[]int{2, 17},
 				[]int{4, 5},
-				[]int{12, 17},
+				[]int{11, 16},
 			},
 		},
 		{

--- a/pkg/markdown/parser/parser.go
+++ b/pkg/markdown/parser/parser.go
@@ -26,6 +26,7 @@ func NewParser() Parser {
 	p.inlineCallback['H'] = maybeAutoLink
 	p.inlineCallback['M'] = maybeAutoLink
 	p.inlineCallback['F'] = maybeAutoLink
+	p.inlineCallback['`'] = codeSpan
 	p.refs = make(map[string]*link, 0)
 	return &p
 }
@@ -33,11 +34,11 @@ func NewParser() Parser {
 // Parse scans data and applies callbacks to character patterns
 // to model a parsed Document
 func (p *parser) Parse(data []byte) Document {
+	var end int
 	doc := &document{
 		data:  data,
 		links: []Link{},
 	}
-	beg, end := 0, 0
 
 	n := len(data)
 	for end < n {
@@ -52,8 +53,7 @@ func (p *parser) Parse(data []byte) Document {
 			end++
 			continue
 		}
-		beg = end + consumed
-		end = beg
+		end += consumed
 		if node != nil {
 			switch v := node.(type) {
 			case *link:
@@ -63,13 +63,6 @@ func (p *parser) Parse(data []byte) Document {
 				}
 			}
 		}
-	}
-	// TODO: leftover block from the original parser.
-	if beg < n {
-		if data[end-1] == '\n' {
-			end--
-		}
-		// 	ast.AppendChild(currBlock, newTextNode(data[beg:end]))
 	}
 	return doc
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Docforge fails to parse links that are inside code span blocks similar to `http://localhost:8080`
