### PR TITLE
bug fix for deleting multiple empty tree nodes

### DIFF
--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -154,7 +154,7 @@ func buildNodes(node *api.Node, excludePaths []string, frontMatter map[string]in
 //   internally to build the structure but are not a valid contentSource
 // - remove empty nodes that do not contain markdown. The build algorithm
 //   is blind for the content of a node and leaves nodes that are folders
-//   containing for example images only adn thus irrelevant to the
+//   containing for example images only and thus irrelevant to the
 //   documentation structure
 func cleanupNodeTree(node *api.Node) {
 	if len(node.Source) > 0 {
@@ -177,10 +177,6 @@ func cleanupNodeTree(node *api.Node) {
 		}
 	}
 	node.Nodes = children
-}
-
-func removeNode(n []*api.Node, i int) []*api.Node {
-	return append(n[:i], n[i+1:]...)
 }
 
 // Cache is indexes GitHub TreeEntries by website resource URLs as keys,

--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -170,21 +170,13 @@ func cleanupNodeTree(node *api.Node) {
 		}
 		cleanupNodeTree(n)
 	}
-	childrenCopy := make([]*api.Node, len(node.Nodes))
-	if len(node.Nodes) > 0 {
-		copy(childrenCopy, node.Nodes)
-	}
-	for i, n := range node.Nodes {
-		if len(n.Nodes) == 0 {
-			if n.NodeSelector != nil {
-				continue
-			}
-			if len(n.Source) == 0 && len(n.Nodes) == 0 {
-				childrenCopy = removeNode(childrenCopy, i)
-			}
-			node.Nodes = childrenCopy
+	children := node.Nodes[:0]
+	for _, n := range node.Nodes {
+		if len(n.Nodes) != 0 || n.NodeSelector != nil || len(n.Source) != 0 {
+			children = append(children, n)
 		}
 	}
+	node.Nodes = children
 }
 
 func removeNode(n []*api.Node, i int) []*api.Node {

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -521,6 +521,57 @@ func TestCleanupNodeTree(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "",
+			node: &api.Node{
+				Name:   "00",
+				Source: "https://github.com/gardener/gardener/tree/master/docs/00",
+				Nodes: []*api.Node{
+					{
+						Name:   "01.md",
+						Source: "https://github.com/gardener/gardener/blob/master/docs/01.md",
+					},
+					{
+						Name:   "02",
+						Source: "https://github.com/gardener/gardener/tree/master/docs/02",
+						Nodes: []*api.Node{
+							{
+								Name:   "021.md",
+								Source: "https://github.com/gardener/gardener/blob/master/docs/021.md",
+							},
+						},
+					},
+					{
+						Name:   "03",
+						Source: "https://github.com/gardener/gardener/tree/master/docs/03",
+						Nodes:  []*api.Node{},
+					},
+					{
+						Name:   "04",
+						Source: "https://github.com/gardener/gardener/tree/master/docs/04",
+						Nodes:  []*api.Node{},
+					},
+				},
+			},
+			wantNode: &api.Node{
+				Name: "00",
+				Nodes: []*api.Node{
+					{
+						Name:   "01.md",
+						Source: "https://github.com/gardener/gardener/blob/master/docs/01.md",
+					},
+					{
+						Name: "02",
+						Nodes: []*api.Node{
+							{
+								Name:   "021.md",
+								Source: "https://github.com/gardener/gardener/blob/master/docs/021.md",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -478,54 +478,7 @@ func TestCleanupNodeTree(t *testing.T) {
 		{
 			name: "",
 			node: &api.Node{
-				Name:   "00",
-				Source: "https://github.com/gardener/gardener/tree/master/docs/00",
-				Nodes: []*api.Node{
-					{
-						Name:   "01.md",
-						Source: "https://github.com/gardener/gardener/blob/master/docs/01.md",
-					},
-					{
-						Name:   "02",
-						Source: "https://github.com/gardener/gardener/tree/master/docs/02",
-						Nodes: []*api.Node{
-							{
-								Name:   "021.md",
-								Source: "https://github.com/gardener/gardener/blob/master/docs/021.md",
-							},
-						},
-					},
-					{
-						Name:   "03",
-						Source: "https://github.com/gardener/gardener/tree/master/docs/03",
-						Nodes:  []*api.Node{},
-					},
-				},
-			},
-			wantNode: &api.Node{
 				Name: "00",
-				Nodes: []*api.Node{
-					{
-						Name:   "01.md",
-						Source: "https://github.com/gardener/gardener/blob/master/docs/01.md",
-					},
-					{
-						Name: "02",
-						Nodes: []*api.Node{
-							{
-								Name:   "021.md",
-								Source: "https://github.com/gardener/gardener/blob/master/docs/021.md",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "",
-			node: &api.Node{
-				Name:   "00",
-				Source: "https://github.com/gardener/gardener/tree/master/docs/00",
 				Nodes: []*api.Node{
 					{
 						Name:   "01.md",


### PR DESCRIPTION
**What this PR does / why we need it**:
With the current implementation nodes that have child nodes are considered empty and removed, this may lead to panic of type:
 `panic: runtime error: slice bounds out of range [4:2]`
This PR changes the strategy of removing such nodes by creating a new list without the "empty" nodes and later overwriting the existing. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I've added a unit test that is covering this case scenario.
