### PR TITLE
Synchronize error propagation to prevent program freeze

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -309,9 +309,9 @@ func TestDispatchError(t *testing.T) {
 }
 
 func TestDispatchFaultTolerantOnError(t *testing.T) {
-	tasksCount := 10
+	tasksCount := 200
 	minWorkers := 0
-	maxWorkers := 5
+	maxWorkers := 25
 	timeout := 1 * time.Second
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/reactor/build.go
+++ b/pkg/reactor/build.go
@@ -41,7 +41,7 @@ func (r *Reactor) Build(ctx context.Context, documentationStructure []*api.Node)
 		close(gitInfoShutdownCh)
 		close(documentShutdownCh)
 		close(doneCh)
-		klog.V(2).Infoln("Build finished")
+		klog.V(1).Infoln("Build finished")
 	}()
 
 	// start download controller


### PR DESCRIPTION
**What this PR does / why we need it**:
During the download of documents or resources that they refer to, the program is prone to errors (e.g "Resource not found"). Because of the concurrency model of Docforge, to collect these errors, from multiple workers a list of go channels is used. To synchronize the creation of error channels from the workers and to prevent multiple read/writes to the list, a read/write lock is added to the list.

**Fixes** #146

**Release note**:
```noteworthy user
Fixes a synchronization problem that was observed when having multiple errors during document download.
```
