### PR TITLE
add ghost root node to structure direct children

### DIFF
--- a/pkg/api/nodes.go
+++ b/pkg/api/nodes.go
@@ -14,7 +14,7 @@ func (n *Node) Parent() *Node {
 	return n.parent
 }
 
-// SetParent returns the parent node (if any) of this node n
+// SetParent assigns a parent node reference to node n to form upstream hierarchy
 func (n *Node) SetParent(node *Node) {
 	n.parent = node
 }

--- a/pkg/reactor/content_processor.go
+++ b/pkg/reactor/content_processor.go
@@ -340,7 +340,7 @@ func buildDownloadDestination(node *api.Node, resourceName, root string) string 
 	}
 	resourceRelPath := fmt.Sprintf("%s/%s", root, resourceName)
 	parentsSize := len(node.Parents())
-	for ; parentsSize > 0; parentsSize-- {
+	for ; parentsSize > 1; parentsSize-- {
 		resourceRelPath = "../" + resourceRelPath
 	}
 	return resourceRelPath

--- a/pkg/reactor/reactor.go
+++ b/pkg/reactor/reactor.go
@@ -138,6 +138,14 @@ func (r *Reactor) ResolveManifest(ctx context.Context, manifest *api.Documentati
 		return err
 	}
 
+	rootNode := &api.Node{
+		Nodes: []*api.Node{},
+	}
+	for _, n := range structure {
+		n.SetParent(rootNode)
+		rootNode.Nodes = append(rootNode.Nodes, n)
+	}
+
 	manifest.Structure = structure
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a ghost root node and configures the downstream hierarchy so that that it becomes parent to the members of the Structure array of Nodes and the upstream hierarchy so that Nodes in the structure array have it set as its parent.

This is a minimal intervention change to fix the issue that the nodes in the Structure array had no common parent and traversal algorithms were scoped within each of these node's hierarchy, but could not reach out to peer structure nodes. That affects the computation of relative links. 
As a by-product of enforcing a common root node correctly, now top-level `NodesSelector`'s hierarchy is preset correctly.

**Which issue(s) this PR fixes**:
Fixes #150 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed an issue with simple manifests with a single top-level `NodeSelector`, which had their links always absolute even when referencing resolved and downloaded documents from the structure.
```
