### PR TITLE
cache uses a key generated using ResourceLocator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,15 +11,14 @@ require (
 	github.com/howeyc/fsnotify v0.9.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/onsi/ginkgo v1.14.2
+	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/klog/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
-github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
+github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -243,6 +243,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -254,6 +255,7 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -275,6 +277,7 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -304,6 +307,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -324,10 +328,12 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -355,7 +361,10 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc h1:NCy3Ohtk6Iny5V/reW2Ktypo4zIpWBdRJ1uFMjBxdg8=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,7 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc h1:NCy3Ohtk6Iny5V/reW2Ktypo4zIpWBdRJ1uFMjBxdg8=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/processors/processor.go
+++ b/pkg/processors/processor.go
@@ -24,6 +24,9 @@ func (p *ProcessorChain) Process(documentBlob []byte, node *api.Node) ([]byte, e
 	var err error
 	for _, p := range p.Processors {
 		documentBlob, err = p.Process(documentBlob, node)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return documentBlob, err
 }

--- a/pkg/reactor/document_worker.go
+++ b/pkg/reactor/document_worker.go
@@ -130,8 +130,8 @@ func (w *DocumentWorker) Work(ctx context.Context, task interface{}, wq jobs.Wor
 			}
 			if len(task.Node.Source) > 0 {
 				if sourceBlob, err = w.Reader.Read(ctx, task.Node.Source); err != nil {
-					if err == resourcehandlers.ErrResourceNotFound {
-						klog.Warningf("reading %s failed: %s\n", task.Node.Source, err.Error())
+					if resourceNotFound, ok := err.(resourcehandlers.ErrResourceNotFound); ok {
+						klog.Warningf("reading %s failed: %s\n", task.Node.Source, resourceNotFound)
 					}
 					return jobs.NewWorkerError(err, 0)
 				}

--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -224,7 +224,7 @@ func (c *Cache) Key(rl *ResourceLocator) string {
 		path = path[:strings.IndexRune(path, '?')]
 	}
 
-	return fmt.Sprintf("%s:%s:%s:%s:%s", host, owner, repo, path, shaAlias)
+	return fmt.Sprintf("%s:%s:%s:%s:%s", host, owner, repo, shaAlias, path)
 }
 
 // HasURLPrefix returns true if pathPrefix tests true as prefix for path,
@@ -250,7 +250,7 @@ func (c *Cache) GetSubset(pathPrefix string) []*ResourceLocator {
 		if k == c.Key(rl) {
 			continue
 		}
-		if HasURLPrefix(k, c.Key(rl)) {
+		if strings.HasPrefix(k, c.Key(rl)) {
 			entries = append(entries, v)
 		}
 	}

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -144,6 +144,18 @@ func TestUrlToGitHubLocator(t *testing.T) {
 			ghrl2,
 		},
 		{
+			"GitHub url should return valid GitHubResourceLocator from cache raw as query parameter",
+			"https://github.com/gardener/gardener/blob/master/docs/README.md?raw=true",
+			false,
+			&Cache{
+				cache: map[string]*ResourceLocator{
+					"github.com:gardener:gardener:master:docs/readme.md": ghrl2,
+				},
+			},
+			nil,
+			ghrl2,
+		},
+		{
 			"non-cached url should resolve a valid GitHubResourceLocator from API",
 			"https://github.com/gardener/gardener/blob/master/docs/README.md",
 			true,
@@ -320,8 +332,8 @@ func TestResolveNodeSelector(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		// ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-		// defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
 		gh := &GitHub{
 			cache: &Cache{
 				cache: map[string]*ResourceLocator{},
@@ -333,7 +345,7 @@ func TestResolveNodeSelector(t *testing.T) {
 			c.mux(mux)
 		}
 		gh.Client = client
-		nodes, gotError := gh.ResolveNodeSelector(context.TODO(), c.inNode, c.excludePaths, c.frontMatter, c.excludeFrontMatter, c.depth)
+		nodes, gotError := gh.ResolveNodeSelector(ctx, c.inNode, c.excludePaths, c.frontMatter, c.excludeFrontMatter, c.depth)
 		if gotError != nil {
 			t.Errorf("error == %q, want %q", gotError, c.wantError)
 		}

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -116,7 +116,7 @@ func TestUrlToGitHubLocator(t *testing.T) {
 			false,
 			&Cache{
 				cache: map[string]*ResourceLocator{
-					"https://github.com/gardener/gardener/blob/master/docs/README.md": ghrl1,
+					"github.com:gardener:gardener:docs/readme.md:master": ghrl1,
 				},
 			},
 			nil,
@@ -290,7 +290,6 @@ func TestResolveNodeSelector(t *testing.T) {
 			c.mux(mux)
 		}
 		gh.Client = client
-
 		nodes, gotError := gh.ResolveNodeSelector(ctx, c.inNode, c.excludePaths, c.frontMatter, c.excludeFrontMatter, c.depth)
 		if gotError != nil {
 			t.Errorf("error == %q, want %q", gotError, c.wantError)
@@ -338,7 +337,7 @@ func TestName(t *testing.T) {
 			"https://github.com/gardener/gardener/blob/master/docs/README.md",
 			&Cache{
 				cache: map[string]*ResourceLocator{
-					"https://github.com/gardener/gardener/blob/master/docs/README.md": ghrl1,
+					"github.com:gardener:gardener:docs/readme.md:master": ghrl1,
 				},
 			},
 			"README",
@@ -349,7 +348,7 @@ func TestName(t *testing.T) {
 			"https://github.com/gardener/gardener/tree/master/docs",
 			&Cache{
 				cache: map[string]*ResourceLocator{
-					"https://github.com/gardener/gardener/tree/master/docs": ghrl2,
+					"github.com:gardener:gardener:docs:master": ghrl2,
 				},
 			},
 			"docs",
@@ -386,7 +385,7 @@ func TestRead(t *testing.T) {
 			},
 			&Cache{
 				cache: map[string]*ResourceLocator{
-					"https://github.com/gardener/gardener/blob/master/docs/README.md": {
+					"github.com:gardener:gardener:docs/readme.md:master": {
 						"https",
 						"github.com",
 						"gardener",
@@ -410,9 +409,7 @@ func TestRead(t *testing.T) {
 		client, mux, serverURL, teardown := setup()
 		defer teardown()
 		// rewrite cached url keys host to match the mock server
-		for k, v := range c.cache.cache {
-			c.cache.cache[strings.Replace(k, "https://github.com", serverURL, 1)] = v
-		}
+
 		gh := &GitHub{
 			cache: c.cache,
 		}
@@ -606,7 +603,7 @@ func TestTreeEntryToGitHubLocator(t *testing.T) {
 				shaAlias: "master",
 			},
 			expectedRL: &ResourceLocator{
-				Host:     "api.github.com",
+				Host:     "github.com",
 				Owner:    "test-org",
 				Repo:     "test-repo",
 				Path:     "docs/cluster_resources.md",
@@ -630,7 +627,7 @@ func TestTreeEntryToGitHubLocator(t *testing.T) {
 				shaAlias: "master",
 			},
 			expectedRL: &ResourceLocator{
-				Host:     "api.github.com",
+				Host:     "github.com",
 				Owner:    "test-org",
 				Repo:     "test-repo",
 				Path:     "docs/cluster_resources.md",

--- a/pkg/resourcehandlers/github/resource_locator.go
+++ b/pkg/resourcehandlers/github/resource_locator.go
@@ -244,15 +244,14 @@ func parse(urlString string) (*ResourceLocator, error) {
 		path = fmt.Sprintf("%s?%s", path, u.RawQuery)
 	}
 	ghRL := &ResourceLocator{
-		u.Scheme,
-		host,
-		owner,
-		repo,
-		"",
-		resourceType,
-		path,
-		shaAlias,
-		isRawAPI,
+		Scheme:   u.Scheme,
+		Host:     host,
+		Owner:    owner,
+		Repo:     repo,
+		Type:     resourceType,
+		Path:     path,
+		SHAAlias: shaAlias,
+		IsRawAPI: isRawAPI,
 	}
 	return ghRL, nil
 }

--- a/pkg/resourcehandlers/resource_handlers.go
+++ b/pkg/resourcehandlers/resource_handlers.go
@@ -6,14 +6,18 @@ package resourcehandlers
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/gardener/docforge/pkg/api"
 )
 
-// ErrIsResourceNotFound indicated that a resource was not found
-var ErrResourceNotFound = errors.New("resource not found")
+// ErrResourceNotFound indicated that a resource was not found
+type ErrResourceNotFound string
+
+func (e ErrResourceNotFound) Error() string {
+	return fmt.Sprintf("resource %q not found", string(e))
+}
 
 // ResourceHandler does resource specific operations on a type of objects
 // identified by an uri schema that it accepts to handle


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a simplified key, based on the resource locators, that is used for caching the GitHub resources. The new key is host agnostic meaning (github.com or raw.githubusercontent.com are in the end the same) 

**Which issue(s) this PR fixes**:
Fixes an issue that was preventing linked resources with "?raw=true" to be discovered in the cache

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
