### PR TITLE
fix link removal

### DIFF
--- a/pkg/markdown/parser/document.go
+++ b/pkg/markdown/parser/document.go
@@ -9,12 +9,27 @@ type document struct {
 	links []Link
 }
 
-func (d *document) ListLinks(cb UpdateMarkdownLinkListed) {
+func (d *document) ListLinks(cb OnLinkListed) error {
 	if cb != nil && d.links != nil {
+		i := 0
 		for _, l := range d.links {
-			cb(l)
+			_l, err := cb(l)
+			if err != nil {
+				return err
+			}
+			if _l != nil {
+				// Copy over only links that were not removed
+				d.links[i] = _l
+				i++
+			}
 		}
+		// Erase truncated values
+		for j := i; j < len(d.links); j++ {
+			d.links[j] = nil
+		}
+		d.links = d.links[:i]
 	}
+	return nil
 }
 
 func (d *document) Bytes() []byte {

--- a/pkg/markdown/parser/links.go
+++ b/pkg/markdown/parser/links.go
@@ -142,9 +142,9 @@ func (l *link) Remove(leaveText bool) {
 	l.document.data = append(l.document.data, text...)
 	l.document.data = append(l.document.data, doc2...)
 	var (
-		needsOffset         bool
-		offset              int
-		removedElementIndex int
+		offset int
+		_l     *link
+		ok     bool
 	)
 	if len(text) > 0 {
 		offset = len(text) - (l.end - l.start)
@@ -152,20 +152,14 @@ func (l *link) Remove(leaveText bool) {
 		offset = l.start - l.end
 	}
 	for i := 0; i < len(l.document.links); i++ {
-		if l.document.links[i] == l {
-			removedElementIndex = i
-			needsOffset = true
+		if _l, ok = l.document.links[i].(*link); !ok {
 			continue
 		}
-		if needsOffset {
-			offsetLinkByteRanges(l.document.links[i].(*link), offset)
+		// links positioned after the removed one get offset
+		if l.end < _l.start {
+			offsetLinkByteRanges(_l, offset)
 		}
 	}
-	l.document.links = remove(l.document.links, removedElementIndex)
-}
-
-func remove(slice []Link, s int) []Link {
-	return append(slice[:s], slice[s+1:]...)
 }
 
 func (l *link) IsImage() bool {

--- a/pkg/markdown/parser/types.go
+++ b/pkg/markdown/parser/types.go
@@ -9,15 +9,18 @@ type Parser interface {
 	Parse(data []byte) Document
 }
 
-// UpdateMarkdownLinkListed is a callback function invoked by the
+// OnLinkListed is a callback function invoked by the
 // ListLinks iterator in Document
-type UpdateMarkdownLinkListed func(link Link)
+type OnLinkListed func(link Link) (Link, error)
 
 // Document is the markdown model parsed from bytes data
 type Document interface {
 	// ListLinks iterates parsed links in this document
-	// and invokes cb on every link
-	ListLinks(cb UpdateMarkdownLinkListed)
+	// and invokes cb on every link. Should the link be
+	// removed, which is signaled by OnLinkListed returning
+	// nil, ListLinks will update the document links list
+	// referenced by each link.
+	ListLinks(cb OnLinkListed) error
 	// Bytes returns the  parsed document content bytes
 	Bytes() []byte
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes positions offset during link removal. 
Fixes links slice removals on the fly.
Propagates update callback errors.

**Which issue(s) this PR fixes**:
Fixes #158 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Fixes a runtime error when multiple links match a rewrite rule to be removed completely from a document.
```
