### PR TITLE
Improve front-matter titles

### DIFF
--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -121,7 +121,9 @@ func WithHugo(reactorOptions *reactor.Options, o *Options) {
 	hugoOptions := o.Hugo
 	reactorOptions.Processor = &processors.ProcessorChain{
 		Processors: []processors.Processor{
-			&processors.FrontMatter{},
+			&processors.FrontMatter{
+				IndexFileNames: hugoOptions.IndexFileNames,
+			},
 			hugo.NewProcessor(hugoOptions),
 		},
 	}

--- a/pkg/hugo/processor.go
+++ b/pkg/hugo/processor.go
@@ -120,9 +120,12 @@ func (f *Processor) rewriteDestination(destination, text, title []byte, nodeName
 	return destination, text, title, nil
 }
 
+// Compares a node name to the configured list of index file
+// and a default name '_index.md' to determine if this node
+// is an index document node.
 func (f *Processor) nodeIsIndexFile(name string) bool {
 	for _, s := range f.IndexFileNames {
-		if strings.HasSuffix(strings.ToLower(name), s) {
+		if strings.ToLower(name) == strings.ToLower(s) {
 			return true
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Considers parent name when node is section index file. Removes common file name delimiters and .md file extension.
Fixes a couple of issues found in hugo and front matter processors.

**Which issue(s) this PR fixes**:
Fixes #164

**Release note**:
```noteworthy user
The `title` front-matter property is generated smarter now. For index nodes it takes the name of the parent node. Name delimiters `_`  and `-` are replaced with space, `.md` extension is removed and finally the string is converted to title case.   
Example 1: A node with name `abc_def-1.md` gets `title: Abc Def 1`    
Example 2: A node with name `README.md` and parent node name `concepts` gets `title: Concepts`, assuming that `README.md` has been specified as index file name via the command line flag `--hugo-section-files`
```
