### PR TITLE
Add web url to files git-data

### DIFF
--- a/pkg/git/types.go
+++ b/pkg/git/types.go
@@ -15,4 +15,5 @@ type GitInfo struct {
 	PublishDate      *string        `json:"publishdate,omitempty"`
 	Author           *github.User   `json:"author,omitempty"`
 	Contributors     []*github.User `json:"contributors,omitempty"`
+	WebURL           *string        `json:"weburl,omitempty"`
 }

--- a/pkg/resourcehandlers/github/gitinfo.go
+++ b/pkg/resourcehandlers/github/gitinfo.go
@@ -36,6 +36,9 @@ func transform(commits []*github.RepositoryCommit) *git.GitInfo {
 
 	lastModifiedDate := nonInternalCommits[0].GetCommit().GetCommitter().GetDate().Format(git.DateFormat)
 	gitInfo.LastModifiedDate = &lastModifiedDate
+	webURL := nonInternalCommits[0].GetHTMLURL()
+	webURL = strings.Split(webURL, "/commit/")[0]
+	gitInfo.WebURL = &webURL
 
 	publishDate := commits[len(nonInternalCommits)-1].GetCommit().GetCommitter().GetDate().Format(git.DateFormat)
 	gitInfo.PublishDate = &publishDate

--- a/pkg/resourcehandlers/github/testdata/test_format_00_out.json
+++ b/pkg/resourcehandlers/github/testdata/test_format_00_out.json
@@ -1,6 +1,7 @@
 {
     "lastmod": "2020-06-18 18:40:47",
     "publishdate": "2020-06-18 15:07:40",
+    "weburl": "https://github.com/gardener/documentation",
     "author": {
       "login": "a-b",
       "id": 52317188,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds git commits `html_url` as `weburl` property in files' gitinfo.

Example:   
With html_url in commit history like that:
```yaml
{
      "sha": "2a97450d964f39ee1b320fecd4c565f83f2590eb",
      "node_id": "MDY6Q29tbWl0MTEzMDMwODQ1OjJhOTc0NTBkOTY0ZjM5ZWUxYjMyMGZlY2Q0YzU2NWY4M2YyNTkwZWI=",
      "html_url": "https://github.com/gardener/documentation/commit/2a97450d964f39ee1b320fecd4c565f83f2590eb",
...
```
we construct weburl in gitinfo like that:
```yaml
{
    ...
    "weburl": "https://github.com/gardener/documentation",
    ...
```

**Which issue(s) this PR fixes**:
Fixes #165

**Release note**:
```noteworthy user
A new proprty `weburl` added to files gitinfo. It is a URL that references the repository hosting the file for which the gitinfo has been created.
```
