### PR TITLE
add GH resource details to git info

### DIFF
--- a/pkg/git/types.go
+++ b/pkg/git/types.go
@@ -16,4 +16,7 @@ type GitInfo struct {
 	Author           *github.User   `json:"author,omitempty"`
 	Contributors     []*github.User `json:"contributors,omitempty"`
 	WebURL           *string        `json:"weburl,omitempty"`
+	SHA              *string        `json:"sha,omitempty"`
+	SHAAlias         *string        `json:"shaalias,omitempty"`
+	Path             *string        `json:"path,omitempty"`
 }

--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -531,6 +531,15 @@ func (gh *GitHub) ReadGitInfo(ctx context.Context, uri string) ([]byte, error) {
 		if gitInfo == nil {
 			return nil, nil
 		}
+		if len(rl.SHA) > 0 {
+			gitInfo.SHA = &rl.SHA
+		}
+		if len(rl.SHAAlias) > 0 {
+			gitInfo.SHAAlias = &rl.SHAAlias
+		}
+		if len(rl.Path) > 0 {
+			gitInfo.Path = &rl.Path
+		}
 		if blob, err = marshallGitInfo(gitInfo); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Amends the produced gitinfo with details from the resource locator for which the gitinfo is generated. 

**Which issue(s) this PR fixes**:
Fixes #170

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
New properties `path`, `sha` and `shaalias` added to gitinfo generated for GitHub resources. The `path` property is the resource path in GitHub after resource type and its sha. `The `shaalias` property is the human readable tag/branch-name assigned to a sha (e.g. `master`). 
```
