### PR TITLE
add Repository type for better concurrent ops with git repos

### DIFF
--- a/pkg/resourcehandlers/git/repository.go
+++ b/pkg/resourcehandlers/git/repository.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+const depth = 1
+
+type State int
+
+const (
+	_ State = iota
+	Prepared
+	Failed
+)
+
+type Repository struct {
+	Auth          http.AuthMethod
+	LocalPath     string
+	RemoteURL     string
+	State         State
+	PreviousError error
+
+	mutex sync.RWMutex
+}
+
+func (r *Repository) Prepare(ctx context.Context, branch string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	switch r.State {
+	case Failed:
+		return r.PreviousError
+	case Prepared:
+		return nil
+	}
+
+	if err := r.prepare(ctx, branch); err != nil {
+		r.State = Failed
+		r.PreviousError = err
+		return err
+	}
+	r.State = Prepared
+	return nil
+}
+
+func (r *Repository) prepare(ctx context.Context, branch string) error {
+	var fetch = true
+	gitRepo, err := git.PlainOpen(r.LocalPath)
+	if err != nil {
+		if err != git.ErrRepositoryNotExists {
+			return err
+		}
+		if gitRepo, err = git.PlainCloneContext(ctx, r.LocalPath, false, &git.CloneOptions{
+			URL:        r.RemoteURL,
+			RemoteName: git.DefaultRemoteName,
+			Depth:      depth,
+			Auth:       r.Auth,
+		}); err != nil {
+			return fmt.Errorf("failed to prepare repo: %s, %v", r.LocalPath, err)
+		}
+		fetch = false
+	}
+
+	if fetch {
+		if err := gitRepo.FetchContext(ctx, &git.FetchOptions{
+			Auth:       r.Auth,
+			Depth:      depth,
+			RemoteName: git.DefaultRemoteName,
+		}); err != nil && err != git.NoErrAlreadyUpToDate {
+			return fmt.Errorf("failed to fetch repository %s: %v", r.LocalPath, err)
+		}
+	}
+
+	w, err := gitRepo.Worktree()
+	if err != nil {
+		return err
+	}
+	if err := w.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewRemoteReferenceName(git.DefaultRemoteName, branch),
+	}); err != nil {
+		return fmt.Errorf("couldn't checkout branch %s for repository %s: %v", branch, r.LocalPath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds more intelligent lock on the git repositories in case multiple workers try to execute operations over them.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
