### PR TITLE
use git for source info data; add local mappings

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -201,6 +201,7 @@ func NewOptions(f *cmdFlags, c configuration.ConfigurationLoader) *Options {
 		ManifestAbsPath:              manifestAbsPath,
 		UseGit:                       f.useGit,
 		HomeDir:                      determineCacheHomeDir(f, config),
+		LocalMappings:                config.ResourceMappings,
 	}
 }
 

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -60,6 +60,7 @@ type Options struct {
 	Hugo                         *hugo.Options
 	UseGit                       bool
 	HomeDir                      string
+	LocalMappings                map[string]string
 }
 
 type Credentials struct {
@@ -168,21 +169,21 @@ func initResourceHandlers(ctx context.Context, o *Options) ([]resourcehandlers.R
 		if err != nil {
 			multierror.Append(errs, err)
 		}
-		rh := newResouceHandler(u.Host, o.HomeDir, creds.Username, creds.OAuthToken, client, o.UseGit)
+		rh := newResouceHandler(u.Host, o.HomeDir, creds.Username, creds.OAuthToken, client, o.UseGit, o.LocalMappings)
 		rhs = append(rhs, rh)
 	}
 
 	return rhs, errs.ErrorOrNil()
 }
 
-func newResouceHandler(host, homeDir string, user *string, token string, client *github.Client, useGit bool) resourcehandlers.ResourceHandler {
+func newResouceHandler(host, homeDir string, user *string, token string, client *github.Client, useGit bool, localMappings map[string]string) resourcehandlers.ResourceHandler {
 	rawHost := "raw." + host
 	if host == "github.com" {
 		rawHost = "raw.githubusercontent.com"
 	}
 
 	if useGit {
-		return git.NewResourceHandler(filepath.Join(homeDir, git.CacheDir), user, token, client, []string{host, rawHost})
+		return git.NewResourceHandler(filepath.Join(homeDir, git.CacheDir), user, token, client, []string{host, rawHost}, localMappings)
 	}
 	return ghrs.NewResourceHandler(client, []string{host, rawHost})
 }

--- a/cmd/configuration/types_configuration.go
+++ b/cmd/configuration/types_configuration.go
@@ -5,8 +5,9 @@
 package configuration
 
 type Config struct {
-	CacheHome *string   `yaml:"cacheHome,omitempty"`
-	Sources   []*Source `yaml:"sources,omitempty"`
+	CacheHome        *string           `yaml:"cacheHome,omitempty"`
+	Sources          []*Source         `yaml:"sources,omitempty"`
+	ResourceMappings map[string]string `yaml:"resourceMappings,omitempty"`
 }
 
 type Source struct {

--- a/pkg/resourcehandlers/fs/fs.go
+++ b/pkg/resourcehandlers/fs/fs.go
@@ -5,21 +5,17 @@
 package fs
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/gardener/docforge/pkg/api"
-	"github.com/gardener/docforge/pkg/git"
 	"github.com/gardener/docforge/pkg/markdown"
 	"github.com/gardener/docforge/pkg/resourcehandlers"
-	"github.com/google/go-github/v32/github"
+	"github.com/gardener/docforge/pkg/resourcehandlers/utils"
 )
 
 type fsHandler struct{}
@@ -131,58 +127,8 @@ func (fs *fsHandler) ResolveDocumentation(ctx context.Context, uri string) (*api
 }
 
 // ReadGitInfo implements resourcehandlers.ResourceHandler#ReadGitInfo
-func (fs *fsHandler) ReadGitInfo(ctx context.Context, uri string) ([]byte, error) {
-	var (
-		log  []*gitLogEntry
-		blob []byte
-		err  error
-	)
-	if !checkGitExists() {
-		return nil, fmt.Errorf("reading Git info for %s failed: git not found in PATH", uri)
-	}
-
-	if log, err = gitLog(uri); err != nil {
-		return nil, err
-	}
-
-	if len(log) == 0 {
-		return nil, nil
-	}
-
-	for _, logEntry := range log {
-		logEntry.Name = strings.Split(logEntry.Name, "<")[0]
-		logEntry.Name = strings.TrimSpace(logEntry.Name)
-	}
-	authorName := log[len(log)-1].Name
-	authorEmail := log[len(log)-1].Email
-	publishD := log[len(log)-1].Date
-	lastModD := log[0].Date
-	gitInfo := &git.GitInfo{
-		PublishDate:      &publishD,
-		LastModifiedDate: &lastModD,
-		Author: &github.User{
-			Name:  &authorName,
-			Email: &authorEmail,
-		},
-		Contributors: []*github.User{},
-	}
-
-	for _, logEntry := range log {
-		if logEntry.Email != *gitInfo.Author.Email {
-			name := logEntry.Name
-			email := logEntry.Email
-			gitInfo.Contributors = append(gitInfo.Contributors, &github.User{
-				Name:  &name,
-				Email: &email,
-			})
-		}
-	}
-
-	if blob, err = json.MarshalIndent(gitInfo, "", "  "); err != nil {
-		return nil, err
-	}
-
-	return blob, nil
+func (d *fsHandler) ReadGitInfo(ctx context.Context, uri string) ([]byte, error) {
+	return utils.ReadGitInfo(ctx, uri, nil)
 }
 
 // ResourceName implements resourcehandlers.ResourceHandler#ResourceName
@@ -219,61 +165,4 @@ func (fs *fsHandler) GetRawFormatLink(absLink string) (string, error) {
 // SetVersion implements resourcehandlers.ResourceHandler#SetVersion
 func (fs *fsHandler) SetVersion(absLink, version string) (string, error) {
 	return absLink, nil
-}
-
-type gitLogEntry struct {
-	Sha     string
-	Author  string
-	Date    string
-	Message string
-	Email   string
-	Name    string
-}
-
-type gitLogEntryAuthor struct {
-}
-
-func gitLog(path string) ([]*gitLogEntry, error) {
-	var (
-		log            []byte
-		err            error
-		errStr         string
-		stdout, stderr bytes.Buffer
-	)
-
-	if _, err := os.Stat(path); err != nil {
-		return nil, err
-	}
-
-	git := exec.Command("git", "log", "--date=short", `--pretty=format:'{%n  "sha": "%H",%n  "author": "%aN <%aE>",%n  "date": "%ad",%n  "message": "%s",%n  "email": "%aE",%n  "name": "%aN"%n },'`, "--follow", path)
-	git.Stdout = &stdout
-	git.Stderr = &stderr
-	if err = git.Run(); err != nil {
-		if _, ok := err.(*exec.ExitError); !ok {
-			return nil, err
-		}
-	}
-	log, errStr = stdout.Bytes(), string(stderr.Bytes())
-	if len(errStr) > 0 {
-		return nil, fmt.Errorf("failed to execute git log for %s:\n%s", path, errStr)
-	}
-
-	logS := string(log)
-	logS = strings.ReplaceAll(logS, "'{", "{")
-	logS = strings.ReplaceAll(logS, "},'", "},")
-	if strings.HasSuffix(logS, ",") {
-		logS = logS[:len(logS)-1]
-	}
-	logS = fmt.Sprintf("[%s]", logS)
-
-	gitLog := []*gitLogEntry{}
-	if err := json.Unmarshal([]byte(logS), &gitLog); err != nil {
-		return nil, err
-	}
-	return gitLog, nil
-}
-
-func checkGitExists() bool {
-	_, err := exec.LookPath("git")
-	return err == nil
 }

--- a/pkg/resourcehandlers/fs/fs_test.go
+++ b/pkg/resourcehandlers/fs/fs_test.go
@@ -5,10 +5,12 @@
 package fs
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
 	"github.com/gardener/docforge/pkg/api"
+	"github.com/gardener/docforge/pkg/resourcehandlers/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +20,7 @@ func TestFSRead(t *testing.T) {
 		err     error
 	)
 	fs := &fsHandler{}
-	if content, err = fs.Read(nil, filepath.Join("testdata", "f00.md")); err != nil {
+	if content, err = fs.Read(context.TODO(), filepath.Join("testdata", "f00.md")); err != nil {
 		t.Fatalf("%s", err.Error())
 	}
 	assert.Equal(t, []byte("Test data"), content)
@@ -26,10 +28,10 @@ func TestFSRead(t *testing.T) {
 
 func TestGitLog(t *testing.T) {
 	var (
-		log []*gitLogEntry
+		log []*utils.GitLogEntry
 		err error
 	)
-	if log, err = gitLog(filepath.Join("testdata", "f00.md")); err != nil {
+	if log, err = utils.GitLog(filepath.Join("testdata", "f00.md")); err != nil {
 		t.Fatalf("%s", err.Error())
 	}
 	assert.NotNil(t, log)
@@ -41,7 +43,7 @@ func TestReadGitInfo(t *testing.T) {
 		err error
 	)
 	fs := &fsHandler{}
-	if log, err = fs.ReadGitInfo(nil, filepath.Join("testdata", "f00.md")); err != nil {
+	if log, err = fs.ReadGitInfo(context.TODO(), filepath.Join("testdata", "f00.md")); err != nil {
 		t.Fatalf("%s", err.Error())
 	}
 	assert.NotNil(t, log)
@@ -91,7 +93,7 @@ func TestResolveNodeSelector(t *testing.T) {
 	for _, n := range expectedNodes {
 		n.SetParent(nil)
 	}
-	nodes, err := fs.ResolveNodeSelector(nil, node, nil, nil, nil, 0)
+	nodes, err := fs.ResolveNodeSelector(context.TODO(), node, nil, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}

--- a/pkg/resourcehandlers/git/repository.go
+++ b/pkg/resourcehandlers/git/repository.go
@@ -14,7 +14,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
-const depth = 1
+// TODO: do not use depth if git info is not enabled.
+const depth = 0
 
 type State int
 

--- a/pkg/resourcehandlers/utils/gitlog.go
+++ b/pkg/resourcehandlers/utils/gitlog.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/gardener/docforge/pkg/git"
+	ghrh "github.com/gardener/docforge/pkg/resourcehandlers/github"
+
+	"github.com/google/go-github/v32/github"
+)
+
+func ReadGitInfo(ctx context.Context, uri string, rl *ghrh.ResourceLocator) ([]byte, error) {
+	var (
+		log  []*GitLogEntry
+		blob []byte
+		err  error
+	)
+
+	// TODO: move to cmd validation
+	if !checkGitExists() {
+		return nil, fmt.Errorf("reading Git info for %s failed: git not found in PATH", uri)
+	}
+
+	if log, err = GitLog(uri); err != nil {
+		return nil, err
+	}
+
+	if len(log) == 0 {
+		return nil, nil
+	}
+
+	for _, logEntry := range log {
+		logEntry.Name = strings.Split(logEntry.Name, "<")[0]
+		logEntry.Name = strings.TrimSpace(logEntry.Name)
+	}
+	authorName := log[len(log)-1].Name
+	authorEmail := log[len(log)-1].Email
+	publishD := log[len(log)-1].Date
+	lastModD := log[0].Date
+	gitInfo := &git.GitInfo{
+		PublishDate:      &publishD,
+		LastModifiedDate: &lastModD,
+		Author: &github.User{
+			Name:  &authorName,
+			Email: &authorEmail,
+		},
+		Contributors: []*github.User{},
+	}
+
+	if rl != nil {
+		s := fmt.Sprintf("%s://%s", rl.Scheme, rl.Host)
+		webURLElements := []string{s, rl.Owner, rl.Repo}
+		webURL := strings.Join(webURLElements, "/")
+		gitInfo.WebURL = &webURL
+		gitInfo.SHAAlias = &rl.SHAAlias
+		gitInfo.Path = &rl.Path
+	}
+
+	for _, logEntry := range log {
+		if logEntry.Email != *gitInfo.Author.Email {
+			name := logEntry.Name
+			email := logEntry.Email
+			gitInfo.Contributors = append(gitInfo.Contributors, &github.User{
+				Name:  &name,
+				Email: &email,
+			})
+		}
+	}
+
+	if blob, err = json.MarshalIndent(gitInfo, "", "  "); err != nil {
+		return nil, err
+	}
+
+	return blob, nil
+}
+
+func GitLog(path string) ([]*GitLogEntry, error) {
+	var (
+		log            []byte
+		err            error
+		errStr         string
+		stdout, stderr bytes.Buffer
+
+		dirPath = path
+	)
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	if !fileInfo.IsDir() {
+		dirPath = filepath.Dir(path)
+	}
+
+	git := exec.Command("git", "-C", dirPath, "log", "--date=short", `--pretty=format:'{%n  "sha": "%H",%n  "author": "%aN <%aE>",%n  "date": "%ad",%n  "message": "%s",%n  "email": "%aE",%n  "name": "%aN"%n },'`, "--follow", path)
+	git.Stdout = &stdout
+	git.Stderr = &stderr
+	if err = git.Run(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			return nil, err
+		}
+	}
+	log, errStr = stdout.Bytes(), stderr.String()
+	if len(errStr) > 0 {
+		return nil, fmt.Errorf("failed to execute git log for %s:\n%s", path, errStr)
+	}
+
+	logS := string(log)
+	logS = strings.ReplaceAll(logS, "'{", "{")
+	logS = strings.ReplaceAll(logS, "},'", "},")
+	if strings.HasSuffix(logS, ",") {
+		logS = logS[:len(logS)-1]
+	}
+	logS = fmt.Sprintf("[%s]", logS)
+
+	gitLog := []*GitLogEntry{}
+	if err := json.Unmarshal([]byte(logS), &gitLog); err != nil {
+		return nil, err
+	}
+	return gitLog, nil
+}
+
+type GitLogEntry struct {
+	Sha     string
+	Author  string
+	Date    string
+	Message string
+	Email   string
+	Name    string
+}
+
+func checkGitExists() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Use Git for building info data for each documentation file.
2. Add the possibility to configure local mappings inside the config file you are using for example:

`~/.docforge/config`:
``` yaml
sources:
  - host: github.com
    credentials:
      username: swilen-iwanow
      oauthToken: ****TOKEN****
resourceMappings:
  https://github.com/garedener/documentation/blob/master/docs/documentation/document1.md: /Users/swilen/git/github.com/garedener/documentation/docs/documentation/document1.md
```
There are three options for providing local mapping: 
a. Repository

```yaml
resourceMappings:
      https://github.com/garedener/documentation: /Users/swilen/git/github.com/garedener/documentation
```
b. Folder 

```yaml
resourceMappings:
    https://github.com/garedener/documentation/blob/master/docs/documentation: /Users/swilen/git/github.com/garedener/documentation/docs/documentation
```
c. File
```yaml
resourceMappings:
    https://github.com/garedener/documentation/blob/master/docs/documentation/document1.md: /Users/swilen/git/github.com/garedener/documentation/docs/documentation/document1.md
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
`--use-git` now uses Git for retrieving source info data (`--github-info-data`) as well instead of the GitHub APIs.
```

```noteworthy user
introducing local mappings for better local development.
```