### PR TITLE
add hugo options to configuration file

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -151,7 +151,6 @@ func NewOptions(f *cmdFlags, c configuration.ConfigurationLoader) *Options {
 	}
 
 	var (
-		hugoOptions  *hugo.Options
 		dryRunWriter io.Writer
 		metering     *Metering
 	)
@@ -159,15 +158,6 @@ func NewOptions(f *cmdFlags, c configuration.ConfigurationLoader) *Options {
 	if f.clientMetering {
 		metering = &Metering{
 			Enabled: f.clientMetering,
-		}
-	}
-
-	if f.hugo {
-		hugoOptions = &hugo.Options{
-			PrettyUrls:     f.hugoPrettyUrls,
-			IndexFileNames: f.hugoSectionFiles,
-			Writer:         nil,
-			BaseURL:        f.hugoBaseURL,
 		}
 	}
 
@@ -197,10 +187,10 @@ func NewOptions(f *cmdFlags, c configuration.ConfigurationLoader) *Options {
 		DryRunWriter:                 dryRunWriter,
 		Resolve:                      f.resolve,
 		GitHubInfoPath:               f.ghInfoDestination,
-		Hugo:                         hugoOptions,
+		Hugo:                         hugoOptions(f, config),
 		ManifestAbsPath:              manifestAbsPath,
 		UseGit:                       f.useGit,
-		HomeDir:                      determineCacheHomeDir(f, config),
+		HomeDir:                      cacheHomeDir(f, config),
 		LocalMappings:                config.ResourceMappings,
 	}
 }
@@ -275,7 +265,7 @@ func getCredentialsSlice(credentialsByHost map[string]*Credentials) []*Credentia
 	return credentials
 }
 
-func determineCacheHomeDir(f *cmdFlags, config *configuration.Config) string {
+func cacheHomeDir(f *cmdFlags, config *configuration.Config) string {
 	if cacheDir, found := os.LookupEnv("DOCFORGE_CACHE_DIR"); found {
 		if cacheDir == "" {
 			klog.Warning("DOCFORGE_CACHE_DIR is set to empty string. Docforge will use the current dir fot the cache")
@@ -298,4 +288,28 @@ func determineCacheHomeDir(f *cmdFlags, config *configuration.Config) string {
 
 	// default value $HOME/.docforge/cache
 	return filepath.Join(userHomeDir, configuration.DocforgeHomeDir)
+}
+
+func hugoOptions(f *cmdFlags, config *configuration.Config) *hugo.Options {
+	if !f.hugo || config.Hugo == nil {
+		return nil
+	}
+
+	hugoOptions := &hugo.Options{
+		PrettyUrls:     f.hugoPrettyUrls,
+		IndexFileNames: f.hugoSectionFiles,
+		Writer:         nil,
+	}
+
+	if f.hugoBaseURL != "" {
+		hugoOptions.BaseURL = f.hugoBaseURL
+		return hugoOptions
+	}
+
+	if config.Hugo != nil {
+		if config.Hugo.BaseURL != nil {
+			hugoOptions.BaseURL = *config.Hugo.BaseURL
+		}
+	}
+	return hugoOptions
 }

--- a/cmd/app/cmd_test.go
+++ b/cmd/app/cmd_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gardener/docforge/cmd/configuration"
+	"github.com/gardener/docforge/pkg/hugo"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+)
+
+func Test_hugoOptions(t *testing.T) {
+	type args struct {
+		f      *cmdFlags
+		config *configuration.Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want *hugo.Options
+	}{
+		{
+			name: "return_nil_when_no_config_or_flag_provided",
+			args: args{
+				f: &cmdFlags{
+					hugo: false,
+				},
+				config: &configuration.Config{
+					Hugo: nil,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "return_default_hugo_options",
+			args: args{
+				f: &cmdFlags{
+					hugo:           true,
+					hugoPrettyUrls: true,
+				},
+				config: &configuration.Config{
+					Hugo: nil,
+				},
+			},
+			want: &hugo.Options{
+				PrettyUrls:     true,
+				IndexFileNames: []string{},
+				BaseURL:        "",
+			},
+		},
+		{
+			name: "use_base_url_from_config_when_not_specified_in_flags",
+			args: args{
+				f: &cmdFlags{
+					hugo:           true,
+					hugoPrettyUrls: true,
+				},
+				config: &configuration.Config{
+					Hugo: &configuration.Hugo{
+						BaseURL: pointer.StringPtr("/new/baseURL"),
+					},
+				},
+			},
+			want: &hugo.Options{
+				PrettyUrls:     true,
+				IndexFileNames: []string{},
+				BaseURL:        "/new/baseURL",
+			},
+		},
+		{
+			name: "use_base_url_from_flags_with_priority",
+			args: args{
+				f: &cmdFlags{
+					hugo:           true,
+					hugoPrettyUrls: true,
+					hugoBaseURL:    "/override",
+				},
+				config: &configuration.Config{
+					Hugo: &configuration.Hugo{
+						BaseURL: pointer.StringPtr("/new/baseURL"),
+					},
+				},
+			},
+			want: &hugo.Options{
+				PrettyUrls:     true,
+				IndexFileNames: []string{},
+				BaseURL:        "/override",
+			},
+		},
+		{
+			name: "set_hugo_base_url_from_flags",
+			args: args{
+				f: &cmdFlags{
+					hugo:           true,
+					hugoPrettyUrls: true,
+					hugoBaseURL:    "/fromFlag",
+				},
+				config: &configuration.Config{
+					Hugo: &configuration.Hugo{
+						BaseURL: nil,
+					},
+				},
+			},
+			want: &hugo.Options{
+				PrettyUrls:     true,
+				IndexFileNames: []string{},
+				BaseURL:        "/fromFlag",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hugoOptions(tt.args.f, tt.args.config); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("hugoOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_prettyURLs(t *testing.T) {
+	type args struct {
+		fromFlag   bool
+		fromConfig *bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "returns_false_flag_default_value_and_configuration_set_to_false",
+			args: args{
+				fromFlag:   true,
+				fromConfig: pointer.BoolPtr(false),
+			},
+			want: false,
+		},
+		{
+			name: "returns_false_flag_set_to_false_and_configuration_set_to_false",
+			args: args{
+				fromFlag:   false,
+				fromConfig: pointer.BoolPtr(false),
+			},
+			want: false,
+		},
+		{
+			name: "returns_false_flag_set_to_false_and_configuration_set_to_true",
+			args: args{
+				fromFlag:   false,
+				fromConfig: pointer.BoolPtr(true),
+			},
+			want: false,
+		},
+		{
+			name: "returns_true_when_both_true",
+			args: args{
+				fromFlag:   true,
+				fromConfig: pointer.BoolPtr(true),
+			},
+			want: true,
+		},
+		{
+			name: "returns_true_flag_set_to_default_or_true_and_configuration_is_not_set",
+			args: args{
+				fromFlag:   true,
+				fromConfig: nil,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prettyURLs(tt.args.fromFlag, &configuration.Hugo{PrettyURLs: tt.args.fromConfig}); tt.want != got {
+				t.Errorf("failed test: %s, wants %t got %t", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_combineSectionFiles(t *testing.T) {
+	type args struct {
+		sectionFilesFromFlags  []string
+		sectionFilesFromConfig []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "successfully_merges",
+			args: args{
+				sectionFilesFromFlags: []string{
+					"index.md",
+					"readme.md",
+				},
+				sectionFilesFromConfig: []string{
+					"readme.md",
+					"readme",
+				},
+			},
+			want: []string{
+				"readme.md",
+				"readme",
+				"index.md",
+			},
+		},
+		{
+			name: "successfully_adds_all_from_flags",
+			args: args{
+				sectionFilesFromFlags: []string{
+					"index.md",
+					"readme.md",
+				},
+				sectionFilesFromConfig: []string{},
+			},
+			want: []string{
+				"readme.md",
+				"index.md",
+			},
+		},
+		{
+			name: "successfully_adds_all_from_config",
+			args: args{
+				sectionFilesFromFlags: []string{},
+				sectionFilesFromConfig: []string{
+					"index.md",
+					"readme.md"},
+			},
+			want: []string{
+				"readme.md",
+				"index.md",
+			},
+		},
+		{
+			name: "empty_input_returns_empty_output",
+			args: args{
+				sectionFilesFromFlags:  []string{},
+				sectionFilesFromConfig: []string{},
+			},
+			want: []string{},
+		},
+		{
+			name: "nil_slices_return_new_empty_slice",
+			args: args{
+				sectionFilesFromFlags:  nil,
+				sectionFilesFromConfig: nil,
+			},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := combineSectionFiles(tt.args.sectionFilesFromFlags, &configuration.Hugo{SectionFiles: tt.args.sectionFilesFromConfig})
+			assert.ElementsMatch(t, got, tt.want)
+		})
+	}
+}

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -122,7 +122,6 @@ func NewReactor(ctx context.Context, options *Options, globalLinksCfg *api.Links
 	if options.Hugo != nil {
 		WithHugo(o, options)
 	}
-
 	return reactor.NewReactor(o), nil
 }
 

--- a/cmd/configuration/types_configuration.go
+++ b/cmd/configuration/types_configuration.go
@@ -22,5 +22,8 @@ type Credentials struct {
 }
 
 type Hugo struct {
-	BaseURL *string `yaml:"baseURL,omitempty"`
+	Enabled      bool     `yaml:"enabled"`
+	PrettyURLs   *bool    `yaml:"prettyURLs,omitempty"`
+	BaseURL      *string  `yaml:"baseURL,omitempty"`
+	SectionFiles []string `yaml:"sectionFiles"`
 }

--- a/cmd/configuration/types_configuration.go
+++ b/cmd/configuration/types_configuration.go
@@ -8,6 +8,7 @@ type Config struct {
 	CacheHome        *string           `yaml:"cacheHome,omitempty"`
 	Sources          []*Source         `yaml:"sources,omitempty"`
 	ResourceMappings map[string]string `yaml:"resourceMappings,omitempty"`
+	Hugo             *Hugo             `yaml:"hugo,omitempty"`
 }
 
 type Source struct {
@@ -18,4 +19,8 @@ type Source struct {
 type Credentials struct {
 	Username   *string `yaml:"username,omitempty"`
 	OAuthToken *string `yaml:"oauthToken,omitempty"`
+}
+
+type Hugo struct {
+	BaseURL *string `yaml:"baseURL,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for Hugo BaseURL (--hugo-base-url), pretty URLs, and section files configuration inside the Docforge config file. 

1.`~/.docforge/config`:
  ```yaml
  hugo:
    baseURL: /base/url
    sectionFiles: ["a", "b.md"]
    prettyURLs: true
  ```

Note that when you have the previous example in your config you are not obligated to specify the --hugo flag either.
Plus you can specify only 
2.`~/.docforge/config`:
  ```yaml
  hugo:
    enabled: true
  ```
without `hugo.baseURL`, Docforge will start behaving as it would when --hugo is specified.

Motivation:
Using GitBash on Windows for working with bash scripts and Docforge in combination leads to errors when providing the `--hugo-base-url` flag when the link begins with `/` (backslash). Mitigation to this scenario is using the configuration file of Docforge.

```noteworthy user
Hugo baseURL, pretty URLs,   can be configured inside the Docforge config file
```
