### PR TITLE
Use hash function for generating names of referenced resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/howeyc/fsnotify v0.9.0
-	github.com/onsi/ginkgo v1.16.2
+	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.10.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.2 h1:HFB2fbVIlhIfCfOW81bZFbiC/RvnpXSdhbF2/DJr134=
-github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -350,13 +350,13 @@ type Downloads struct {
 // expressions:
 //
 // - `$name`: the original name of the resource
-// - `$uuid`: a UUID generated for the resource
+// - `$hash`: a hash generated from the resource's URL
 // - `$ext`: a original resource extension
-//   The default expression applying to all resources is: `$uuid$ext`
+//   The default expression applying to all resources is: `$name_hash$ext`
 //   Example:
 //
 // ```
-//  "\\.(jpg|gif|png)": "$name-image-$uuid$ext"
+//  "\\.(jpg|gif|png)": "$name-image-$hash$ext"
 // ```
 //
 // Optional

--- a/pkg/reactor/links.go
+++ b/pkg/reactor/links.go
@@ -5,13 +5,14 @@
 package reactor
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/util/urls"
-	"github.com/google/uuid"
 	"k8s.io/klog/v2"
 )
 
@@ -128,7 +129,7 @@ func matchForDownload(url *urls.URL, downloadRules *api.Downloads) (string, bool
 				return downloadResourceName, true
 			}
 			// default download resource name
-			downloadResourceName := expandVariables(url, "$uuid$ext")
+			downloadResourceName := expandVariables(url, "$name_$hash$ext")
 			return downloadResourceName, true
 		}
 	}
@@ -158,10 +159,10 @@ func matchDownloadRenameRule(link string, rules map[string]string) string {
 }
 
 func expandVariables(url *urls.URL, renameExpr string) string {
-	id := uuid.New().String()
+	hash := md5.Sum([]byte(url.String()))
 	s := renameExpr
 	s = strings.ReplaceAll(s, "$name", url.ResourceName)
-	s = strings.ReplaceAll(s, "$uuid", id)
+	s = strings.ReplaceAll(s, "$hash", hex.EncodeToString(hash[:])[:6])
 	s = strings.ReplaceAll(s, "$ext", fmt.Sprintf(".%s", url.Extension))
 	return s
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use hash function for generating names of referenced resources instead of UUID

**Which issue(s) this PR fixes**:
Closes #183

**Special notes for your reviewer**:
@swilen-iwanow 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The default regex for generated names of referenced resources now includes `<resource-name>_<abs_url>.<etx>`
```
