### PR TITLE
fix index rename issue

### DIFF
--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -70,7 +70,7 @@ func NewCommand(ctx context.Context, cancel context.CancelFunc) *cobra.Command {
 			if err := api.ValidateManifest(doc); err != nil {
 				return err
 			}
-			reactor, err := NewReactor(ctx, options, doc.Links)
+			reactor, err := NewReactor(ctx, options, rhs, doc.Links)
 			if err != nil {
 				return err
 			}
@@ -139,7 +139,7 @@ func (flags *cmdFlags) Configure(command *cobra.Command) {
 		"Build documentation bundle for hugo with pretty URLs (./sample.md -> ../sample). Only useful with --hugo=true")
 	command.Flags().StringVar(&flags.hugoBaseURL, "hugo-base-url", "", "Rewrites the raltive links of documentation files to root-relative where possible.")
 	command.Flags().BoolVar(&flags.useGit, "use-git", false, "Use Git for replication")
-	command.Flags().StringSliceVar(&flags.hugoSectionFiles, "hugo-section-files", []string{"readme", "read.me", "index"},
+	command.Flags().StringSliceVar(&flags.hugoSectionFiles, "hugo-section-files", []string{"readme.md", "readme", "read.me", "index.md", "index"},
 		"When building a Hugo-compliant documentaton bundle, files with filename matching one form this list (in that order) will be renamed to _index.md. Only useful with --hugo=true")
 }
 

--- a/cmd/app/factory.go
+++ b/cmd/app/factory.go
@@ -76,13 +76,8 @@ type Metering struct {
 }
 
 // NewReactor creates a Reactor from Options
-func NewReactor(ctx context.Context, options *Options, globalLinksCfg *api.Links) (*reactor.Reactor, error) {
+func NewReactor(ctx context.Context, options *Options, rhs []resourcehandlers.ResourceHandler, globalLinksCfg *api.Links) (*reactor.Reactor, error) {
 	dryRunWriters := writers.NewDryRunWritersFactory(options.DryRunWriter)
-
-	rhs, err := initResourceHandlers(ctx, options)
-	if err != nil {
-		return nil, err
-	}
 
 	o := &reactor.Options{
 		MaxWorkersCount:              options.MaxWorkersCount,
@@ -144,6 +139,7 @@ func WithHugo(reactorOptions *reactor.Options, o *Options) {
 			Root: filepath.Join(o.DestinationPath),
 		}
 	}
+	reactorOptions.IndexFileNames = hugoOptions.IndexFileNames
 	reactorOptions.Writer = hugo.NewWriter(hugoOptions)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,10 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/tools v0.1.3 // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/klog/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -86,7 +86,6 @@ github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -288,7 +287,6 @@ github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -319,15 +317,11 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
-golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -361,7 +355,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -422,11 +415,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
-golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/hugo/fswriter.go
+++ b/pkg/hugo/fswriter.go
@@ -5,29 +5,21 @@
 package hugo
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
-	"github.com/gardener/docforge/pkg/markdown"
-	"gopkg.in/yaml.v3"
-	"k8s.io/klog/v2"
-
 	"github.com/gardener/docforge/pkg/api"
-	nodeutil "github.com/gardener/docforge/pkg/util/node"
+	"github.com/gardener/docforge/pkg/markdown"
 	"github.com/gardener/docforge/pkg/writers"
+	"gopkg.in/yaml.v3"
+	"path/filepath"
 )
 
 // FSWriter is implementation of Writer interface for writing blobs
 // to the file system at a designated path in a Hugo-specific way
 type FSWriter struct {
 	Writer         writers.Writer
-	IndexFileNames []string
 }
 
-// Write implements writers#Write and will rename files that match the
-// list in hugo#FSWriter.IndexFileNames to _index.md on first match, first
-// renamed basis to serve as section files.
+// Write implements writers#Write and will create section file #path/#name/_index.md'
+// for node without content, but with frontmatter properties.
 func (w *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) error {
 	if node != nil {
 		if docBlob == nil && node.Properties != nil && node.Properties["frontmatter"] != nil {
@@ -39,40 +31,12 @@ func (w *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 			if b, err = yaml.Marshal(node.Properties["frontmatter"]); err != nil {
 				return err
 			}
-			_name := "_index"
+			_name := "_index.md"
 			if _docBlob, err = markdown.InsertFrontMatter(b, []byte("")); err != nil {
 				return err
 			}
 			if err := w.Writer.Write(_name, filepath.Join(path, name), _docBlob, node); err != nil {
 				return err
-			}
-		}
-
-		// validate
-		if node.Parent() != nil {
-			if ns := getIndexNodes(node.Parent().Nodes); len(ns) > 1 {
-				names := []string{}
-				for _, n := range ns {
-					names = append(names, n.Name)
-				}
-				p := nodeutil.Path(node, "/")
-				return fmt.Errorf("multiple peer nodes with property index: true detected in %s: %s", p, strings.Join(names, ","))
-			}
-		}
-
-		if hasIndexNode([]*api.Node{node}) {
-			name = "_index"
-		}
-		// if IndexFileNames has values and index file has not been
-		// identified, try to figure out index file out from node names.
-		peerNodes := node.Peers()
-		if len(w.IndexFileNames) > 0 && name != "_index" && name != "_index.md" && !hasIndexNode(peerNodes) {
-			for _, s := range w.IndexFileNames {
-				if strings.EqualFold(name, s) {
-					klog.V(6).Infof("Renaming %s -> _index.md\n", filepath.Join(path, name))
-					name = "_index"
-					break
-				}
 			}
 		}
 	}
@@ -81,34 +45,4 @@ func (w *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 		return err
 	}
 	return nil
-}
-
-func hasIndexNode(nodes []*api.Node) bool {
-	for _, n := range nodes {
-		if n.Properties != nil {
-			index := n.Properties["index"]
-			if isIndex, ok := index.(bool); ok {
-				return isIndex
-			}
-			if n.Name == "_index" || n.Name == "_index.md" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func getIndexNodes(nodes []*api.Node) []*api.Node {
-	indexNodes := []*api.Node{}
-	for _, n := range nodes {
-		if n.Properties != nil {
-			index := n.Properties["index"]
-			if isIndex, ok := index.(bool); ok {
-				if isIndex {
-					indexNodes = append(indexNodes, n)
-				}
-			}
-		}
-	}
-	return indexNodes
 }

--- a/pkg/hugo/fswriter_test.go
+++ b/pkg/hugo/fswriter_test.go
@@ -47,7 +47,7 @@ func TestWrite(t *testing.T) {
 			docBlob:      []byte("# Test"),
 			node:         &api.Node{},
 			wantErr:      nil,
-			wantFileName: `test.md`,
+			wantFileName: `test`,
 			wantContent:  `# Test`,
 		},
 		{
@@ -67,28 +67,6 @@ func TestWrite(t *testing.T) {
 title: Test1
 ---
 `,
-		},
-		{
-			name:    "README",
-			path:    "a/b",
-			docBlob: []byte("# Test"),
-			node: &api.Node{
-				Name: "README",
-				Properties: map[string]interface{}{
-					"index": true,
-				},
-				ContentSelectors: []api.ContentSelector{
-					{
-						Source: "github.com",
-					},
-				},
-			},
-			wantErr:      nil,
-			wantFileName: filepath.Join("_index.md"),
-			wantContent:  `# Test`,
-			mutate: func(writer *FSWriter) {
-				writer.IndexFileNames = []string{"readme"}
-			},
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/hugo/hugo.go
+++ b/pkg/hugo/hugo.go
@@ -32,7 +32,6 @@ type Options struct {
 func NewWriter(opts *Options) writers.Writer {
 	return &FSWriter{
 		opts.Writer,
-		opts.IndexFileNames,
 	}
 }
 

--- a/pkg/resourcehandlers/fs/fs.go
+++ b/pkg/resourcehandlers/fs/fs.go
@@ -55,9 +55,9 @@ func (fs *fsHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, ex
 				return nil
 			}
 			if path != parentPath {
-				if len(strings.Split(path, "/"))-len(strings.Split(parentPath, "/")) != 1 {
+				if len(strings.Split(path, string(os.PathSeparator)))-len(strings.Split(parentPath, string(os.PathSeparator))) != 1 {
 					node = node.Parent()
-					pathSegments := strings.Split(path, "/")
+					pathSegments := strings.Split(path, string(os.PathSeparator))
 					if len(pathSegments) > 0 {
 						pathSegments = pathSegments[:len(pathSegments)-1]
 						parentPath = filepath.Join(pathSegments...)
@@ -97,8 +97,8 @@ func (fs *fsHandler) ResolveNodeSelector(ctx context.Context, node *api.Node, ex
 		}
 	}(_node, node.NodeSelector.Path))
 	if len(_node.Nodes) > 0 && len(_node.Nodes[0].Nodes) > 0 {
-		for _, node := range _node.Nodes[0].Nodes {
-			node.SetParent(nil)
+		for _, n := range _node.Nodes[0].Nodes {
+			n.SetParent(nil)
 		}
 		return _node.Nodes[0].Nodes, nil
 	}

--- a/pkg/resourcehandlers/fs/fs_test.go
+++ b/pkg/resourcehandlers/fs/fs_test.go
@@ -72,19 +72,19 @@ func TestResolveNodeSelector(t *testing.T) {
 						Nodes: []*api.Node{
 							{
 								Name:   "f020.md",
-								Source: "testdata/d00/d02/f020.md",
+								Source: filepath.FromSlash("testdata/d00/d02/f020.md"),
 							},
 						},
 					},
 					{
 						Name:   "f01.md",
-						Source: "testdata/d00/f01.md",
+						Source: filepath.FromSlash("testdata/d00/f01.md"),
 					},
 				},
 			},
 			{
 				Name:   "f00.md",
-				Source: "testdata/f00.md",
+				Source: filepath.FromSlash("testdata/f00.md"),
 			},
 		},
 	}
@@ -102,6 +102,8 @@ func TestResolveNodeSelector(t *testing.T) {
 }
 
 func TestBuildAbsLink(t *testing.T) {
+	absLink, _ := filepath.Abs("/d/e/f.md")
+	absWantLink, _ := filepath.Abs("/d/e/f.md")
 	testCases := []struct {
 		source   string
 		link     string
@@ -110,8 +112,8 @@ func TestBuildAbsLink(t *testing.T) {
 	}{
 		{
 			source:   "a/b/c.md",
-			link:     "/d/e/f.md",
-			wantLink: "/d/e/f.md",
+			link:     absLink,
+			wantLink: absWantLink,
 		},
 		{
 			source:   "a/b/c.md",

--- a/pkg/resourcehandlers/testhandler/test_resource_handler.go
+++ b/pkg/resourcehandlers/testhandler/test_resource_handler.go
@@ -15,6 +15,7 @@ type TestResourceHandler struct {
 	accept               func(uri string) bool
 	resolveNodeSelector  func(ctx context.Context, node *api.Node, excludePaths []string, frontMatter map[string]interface{}, excludeFrontMatter map[string]interface{}, depth int32) ([]*api.Node, error)
 	resolveDocumentation func(ctx context.Context, uri string) (*api.Documentation, error)
+	resourceName         func(link string) (string, string)
 }
 
 //NewTestResouceHandlere ...
@@ -63,7 +64,16 @@ func (t *TestResourceHandler) ReadGitInfo(ctx context.Context, uri string) ([]by
 // ResourceName returns a breakdown of a resource name in the link, consisting
 // of name and potentially and extention without the dot.
 func (t *TestResourceHandler) ResourceName(link string) (string, string) {
+	if t.resourceName != nil {
+		return t.resourceName(link)
+	}
 	return "", ""
+}
+
+// WithResourceName ...
+func (t *TestResourceHandler) WithResourceName(resourceName func(link string) (string, string)) *TestResourceHandler {
+	t.resourceName = resourceName
+	return t
 }
 
 // BuildAbsLink should return an absolute path of a relative link in regards of the provided

--- a/pkg/writers/dryRunWriter.go
+++ b/pkg/writers/dryRunWriter.go
@@ -121,7 +121,7 @@ func format(files []*file, b *bytes.Buffer) {
 	for _, f := range files {
 		p := f.path
 		p = filepath.Clean(p)
-		dd := strings.Split(p, "/")
+		dd := strings.Split(p, string(filepath.Separator))
 		indent := 0
 		for i, s := range dd {
 			if i > 0 {
@@ -129,7 +129,7 @@ func format(files []*file, b *bytes.Buffer) {
 				indent++
 			}
 			idx := i + 1
-			_p := strings.Join(dd[:idx], "/")
+			_p := filepath.Join(dd[:idx] ...)
 			if !any(all, _p) {
 				all = append(all, _p)
 				b.WriteString(fmt.Sprintf("%s\n", s))

--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -6,12 +6,10 @@ package writers
 
 import (
 	"fmt"
+	"github.com/gardener/docforge/pkg/api"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/gardener/docforge/pkg/api"
 )
 
 // FSWriter is implementation of Writer interface for writing blobs to the file system
@@ -30,10 +28,6 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *api.Node) erro
 	}
 	if err := os.MkdirAll(p, os.ModePerm); err != nil {
 		return err
-	}
-
-	if node != nil && !strings.HasSuffix(name, ".md") {
-		name = fmt.Sprintf("%s.md", name)
 	}
 
 	if len(f.Ext) > 0 {

--- a/pkg/writers/fswriter_test.go
+++ b/pkg/writers/fswriter_test.go
@@ -27,12 +27,21 @@ func TestWrite(t *testing.T) {
 		wantContent  string
 	}{
 		{
-			name:         "test",
+			name:         "test.md",
 			path:         "a/b",
 			docBlob:      []byte("# Test"),
 			node:         &api.Node{},
 			wantErr:      nil,
 			wantFileName: `test.md`,
+			wantContent:  `# Test`,
+		},
+		{
+			name:         "test",
+			path:         "a/b",
+			docBlob:      []byte("# Test"),
+			node:         &api.Node{},
+			wantErr:      nil,
+			wantFileName: `test`,
 			wantContent:  `# Test`,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**
There is an issue with filenames stored under **/data/** folder. When node has `index=true` property, git info content is not stored in **_index.md.json** as expected, but in **<node.Name>.json** instead.

Which issue(s) this PR fixes:
Fixes #
#191 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
None
```
