### PR TITLE
fix absolute links build

### DIFF
--- a/pkg/resourcehandlers/git/git_resource_handler.go
+++ b/pkg/resourcehandlers/git/git_resource_handler.go
@@ -273,13 +273,17 @@ func (g *Git) BuildAbsLink(source, relPath string) (string, error) {
 	}
 
 	if strings.HasPrefix(relPath, "/") {
-		relPath = strings.TrimPrefix(relPath, "/")
-		rl, err := github.Parse(source)
-		if err != nil {
-			return "", fmt.Errorf("failed to build absolute link for source file located at %s and relative path %s: %v", source, relPath, err)
+		// local link path starting from repo root
+		var rl *github.ResourceLocator
+		if rl, err = github.Parse(source); err != nil {
+			return "", err
 		}
-		rl.Path = relPath
-		return rl.String(), nil
+		if rl != nil  {
+			repo := fmt.Sprintf("/%s/%s/%s/%s", rl.Owner, rl.Repo, rl.Type, rl.SHAAlias)
+			if ! strings.HasPrefix(relPath, repo + "/") {
+				relPath = fmt.Sprintf("%s%s", repo, relPath)
+			}
+		}
 	}
 
 	u, err = u.Parse(relPath)

--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -511,6 +511,19 @@ func (gh *GitHub) BuildAbsLink(source, relPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if strings.HasPrefix(relPath, "/") {
+		// local link path starting from repo root
+		var rl *ResourceLocator
+		if rl, err = Parse(source); err != nil {
+			return "", err
+		}
+		if rl != nil  {
+			repo := fmt.Sprintf("/%s/%s/%s/%s", rl.Owner, rl.Repo, rl.Type, rl.SHAAlias)
+			if ! strings.HasPrefix(relPath, repo + "/") {
+				relPath = fmt.Sprintf("%s%s", repo, relPath)
+			}
+		}
+	}
 	u, err = u.Parse(relPath)
 	if err != nil {
 		return "", err

--- a/pkg/resourcehandlers/github/github_resource_handler_test.go
+++ b/pkg/resourcehandlers/github/github_resource_handler_test.go
@@ -510,6 +510,14 @@ func TestGitHub_ResolveRelLink(t *testing.T) {
 			},
 			wantRelLink: "https://github.com/gardener/gardener/master/tree/images/jjbj.png",
 		},
+		{
+			name: "test root link",
+			args: args{
+				source: "https://github.com/gardener/external-dns-management/blob/master/README.md",
+				link:   "/docs/aws-route53/README.md",
+			},
+			wantRelLink: "https://github.com/gardener/external-dns-management/blob/master/docs/aws-route53/README.md",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Markdown links that point to a repository root (i.e.. starts with "/") is not properly build as absolute links.

**Which issue(s) this PR fixes**:
Fixes #194

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
