### PR TITLE
Fix the type of relative links & add win FS support to git resource handler

### DIFF
--- a/pkg/resourcehandlers/github/github_resource_handler.go
+++ b/pkg/resourcehandlers/github/github_resource_handler.go
@@ -496,7 +496,17 @@ func (gh *GitHub) BuildAbsLink(source, relPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return u.String(), err
+	// if relative path ends with '/' change the type to Tree
+	if strings.HasSuffix(relPath, "/") {
+		var trl *ResourceLocator
+		if trl, err = Parse(u.String()); err != nil {
+			return "", err
+		}
+		trl.Type = Tree // change the type
+		return trl.String(), nil
+	} else {
+		return u.String(), nil
+	}
 }
 
 // SetVersion replaces the version segment in the path of GitHub URLs if


### PR DESCRIPTION
**What this PR does / why we need it**:
- The type of relative links that points to folders is changed from 'blob' to 'tree'
- Fit git resource handler to support '\' file separator
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
