### PR TITLE
Verify the resource type of relative links

### DIFF
--- a/pkg/reactor/content_processor.go
+++ b/pkg/reactor/content_processor.go
@@ -242,13 +242,13 @@ func (c *nodeContentProcessor) resolveLink(ctx context.Context, document *proces
 		}
 		// build absolute path for the destination using contentSourcePath as base
 		if absLink, err = handler.BuildAbsLink(contentSourcePath, destination); err != nil {
-			return link, nil, err
+			if _, ok = err.(resourcehandlers.ErrResourceNotFound); ok {
+				klog.Warningf("failed to validate absolute link for %s from source %s: %v\n", destination, contentSourcePath, err)
+			} else {
+				return link, nil, err
+			}
 		}
 		link.AbsLink = &absLink
-
-		if _, err := handler.Read(ctx, absLink); err != nil {
-			klog.Warningf("failed to read absolute link %s: %v\n", absLink, err)
-		}
 	}
 	// rewrite link if required
 	if gLinks := c.globalLinksConfig; gLinks != nil {

--- a/pkg/reactor/document_worker.go
+++ b/pkg/reactor/document_worker.go
@@ -149,8 +149,9 @@ func (w *DocumentWorker) Work(ctx context.Context, task interface{}, wq jobs.Wor
 				if err != nil {
 					if resourceNotFound, ok := err.(resourcehandlers.ErrResourceNotFound); ok {
 						klog.Warningf("reading %s failed: %s\n", task.Node.Source, resourceNotFound)
+					} else {
+						return jobs.NewWorkerError(err, 0)
 					}
-					return jobs.NewWorkerError(err, 0)
 				}
 				if len(sourceBlob) == 0 {
 					klog.Warningf("No content read from node %s source %s:", task.Node.Name, task.Node.Source)

--- a/pkg/resourcehandlers/github/resource_locator_cache.go
+++ b/pkg/resourcehandlers/github/resource_locator_cache.go
@@ -43,7 +43,7 @@ func (c *Cache) Key(rl *ResourceLocator) (string, error) {
 		host = "github.com"
 	}
 
-	u, err := url.Parse(rl.Path)
+	u, err := url.Parse(strings.TrimSuffix(rl.Path, "/"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Verify the resource type of relative links ( blob | tree ):
- changes the type of the link if necessary
- if the link target resource does not exist, throws ErrResourceNotFound

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
