### PR TITLE
Add default values to the int test org and version variables

### DIFF
--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -94,16 +94,21 @@ docforge_bin="${docforge_repo_path}/bin/docforge"
 
 echo "Docforge version: $(${docforge_bin} version)"
 
-org=${INT_TEST_MANIFEST_ORG:-kubernetes}
-version=${INT_TEST_MANIFEST_VERSION:-master}
+org=""
+version=""
 
-if [[ -z "${INT_TEST_MANIFEST_ORG}" ]] || [[ -z "${INT_TEST_MANIFEST_VERSION}" ]]; then
-  echo "Trying to get manifest org and version from ${docforge_repo_path}/.git"
+if [[ ! -z "${INT_TEST_MANIFEST_ORG}" ]] && [[ ! -z "${INT_TEST_MANIFEST_VERSION}" ]]; then
+  echo "Retrieving org and version from env vars"
+  org=${INT_TEST_MANIFEST_ORG}
+  version=${INT_TEST_MANIFEST_VERSION}
+elif [[ -f "${docforge_repo_path}/.git/userlogin" ]] && [[ -f "${docforge_repo_path}/.git/branch" ]]; then
+  echo "Retrieving org and version from ${docforge_repo_path}/.git"
   org=$(cat "${docforge_repo_path}/.git/userlogin")
   version=$(cat "${docforge_repo_path}/.git/branch")
 else
-  org=${INT_TEST_MANIFEST_ORG}
-  version=${INT_TEST_MANIFEST_VERSION}
+  echo "Using default org and version"
+  org="gardener"
+  version="master"
 fi
 
 echo "Manifest org: ${org}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add default values to the int test org and version variables

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@dimitar-kostadinov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
None
```
