### PR TITLE
Add check for nill ResourceLocator on Git tree entries

### DIFF
--- a/pkg/resourcehandlers/github/resource_locator_cache.go
+++ b/pkg/resourcehandlers/github/resource_locator_cache.go
@@ -7,12 +7,13 @@ package github
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/docforge/pkg/resourcehandlers"
-	"github.com/google/go-github/v32/github"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/gardener/docforge/pkg/resourcehandlers"
+	"github.com/google/go-github/v32/github"
 )
 
 // Cache is indexes GitHub TreeEntries by website resource URLs as keys,
@@ -188,11 +189,13 @@ func (c *Cache) set(ctx context.Context, rl *ResourceLocator) (bool, error) {
 	}
 	var eKey string
 	for _, entry := range gitTree.Entries {
-		eRL := TreeEntryToGitHubLocator(entry, rl.SHAAlias)
-		if eKey, err = c.key(eRL, false); err != nil {
-			return false, err
+		if eRL := TreeEntryToGitHubLocator(entry, rl.SHAAlias); eRL != nil {
+			if eKey, err = c.key(eRL, false); err != nil {
+				return false, err
+			}
+
+			c.cache[eKey] = eRL
 		}
-		c.cache[eKey] = eRL
 	}
 	// add root repo key if not already added
 	if _, ok := c.cache[repo]; !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add check for nil ResourceLocator on Git tree entries. In this way, the issue when the manifest points to repo which contains submodules will be resolved.

**Which issue(s) this PR fixes**:
Fixes #226

**Special notes for your reviewer**:
@dimitar-kostadinov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
None
```
