### PR TITLE
Do not use token in check-manifest

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -20,6 +20,6 @@ curl https://raw.githubusercontent.com/gardener/documentation/master/.ci/check-m
 scriptPath="$(${READLINK_BIN} -f ${tmpDir}/check-manifest-entrypoint.sh)"
 configPath="$(${READLINK_BIN} -f ${tmpDir}/manifest-config)"
 
-${scriptPath} --repo-path ${repoPath} --repo-name "docforge" --use-token true --manifest-path ${manifestPath} --diff-dirs ${diffDirs} --config-path ${configPath}
+${scriptPath} --repo-path ${repoPath} --repo-name "docforge" --use-token false --manifest-path ${manifestPath} --diff-dirs ${diffDirs} --config-path ${configPath}
 
 rm -rf ${tmpDir}


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not use token in check-manifest

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
None
```
