### PR TITLE
Update check-manifest to support relative paths in manifest.yaml

### DIFF
--- a/.ci/check-manifest
+++ b/.ci/check-manifest
@@ -10,16 +10,15 @@ else
   READLINK_BIN="readlink"
 fi
 
-repoPath="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+repoPath="$(${READLINK_BIN} -f "$(dirname "${0}")/..")"
 manifestPath="${repoPath}/.docforge/manifest.yaml"
 diffDirs=".docforge/;docs/"
 
 tmpDir=$(mktemp -d)
-curl https://raw.githubusercontent.com/gardener/documentation/master/.ci/check-manifest --output ${tmpDir}/check-manifest-entrypoint.sh && chmod +x ${tmpDir}/check-manifest-entrypoint.sh
-curl https://raw.githubusercontent.com/gardener/documentation/master/.ci/check-manifest-config --output ${tmpDir}/manifest-config
-scriptPath="$(${READLINK_BIN} -f ${tmpDir}/check-manifest-entrypoint.sh)"
-configPath="$(${READLINK_BIN} -f ${tmpDir}/manifest-config)"
+curl https://raw.githubusercontent.com/gardener/documentation/master/.ci/check-manifest --output "${tmpDir}/check-manifest-entrypoint.sh" && chmod +x "${tmpDir}/check-manifest-entrypoint.sh"
+curl https://raw.githubusercontent.com/gardener/documentation/master/.ci/check-manifest-config --output "${tmpDir}/manifest-config"
+scriptPath="$(${READLINK_BIN} -f "${tmpDir}/check-manifest-entrypoint.sh")"
+configPath="$(${READLINK_BIN} -f "${tmpDir}/manifest-config")"
 
-${scriptPath} --repo-path ${repoPath} --repo-name "docforge" --use-token false --manifest-path ${manifestPath} --diff-dirs ${diffDirs} --config-path ${configPath}
-
-rm -rf ${tmpDir}
+${scriptPath} --repo-path "${repoPath}" --repo-name "docforge" --use-token false --manifest-path "${manifestPath}" --diff-dirs ${diffDirs} --config-path "${configPath}"
+rm -rf "${tmpDir}"

--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,8 +1,6 @@
-{{- $vers := Split .versions "," -}}
-{{ $defaultBranch := (index $vers 0) }}
 structure:
 - name: _index.md
-  source: https://github.com/gardener/docforge/blob/{{$defaultBranch}}/README.md
+  source: /README.md
 - name: docs
   nodesSelector:
-    path: https://github.com/gardener/docforge/tree/{{$defaultBranch}}/docs
+    path: /docs


### PR DESCRIPTION
**What this PR does / why we need it**:
Update /.docforge/manifest.yaml with relative paths
Adds option to defines config file location using DOCFORGE_CONFIG env
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
None
```
