### PR TITLE
Avoid unexpected EOF errors, using cache for 'docs' repo folders

### DIFF
--- a/pkg/reactor/reactor_test.go
+++ b/pkg/reactor/reactor_test.go
@@ -56,7 +56,7 @@ func createNewDocumentation() *api.Documentation {
 
 func Test_getNodeParentPath(t *testing.T) {
 	type args struct {
-		node     *api.Node
+		node    *api.Node
 		parents []*api.Node
 	}
 	tests := []struct {

--- a/pkg/util/resource_info.go
+++ b/pkg/util/resource_info.go
@@ -30,9 +30,6 @@ func BuildResourceInfo(uri string) (*ResourceInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	/*if len(u.Path) == 0 { // TODO: Do we need this restriction
-		return nil, fmt.Errorf("unsupported GitHub URL: %s; at least host and organization|owner should be defined", uri)
-	}*/
 	// 'github.com' && 'github.tools.sap' uses host 'raw' prefix
 	// https://raw.githubusercontent.com/gardener/gardener/master/logo/gardener-large.png
 	// https://raw.github.tools.sap/kubernetes/documentation/master/images/overview.png


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid unexpected EOF errors, using cache for 'docs' repo folders
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
None
```
