### PR TITLE
Fix bug with the document titles

### DIFF
--- a/pkg/reactor/content_processor.go
+++ b/pkg/reactor/content_processor.go
@@ -10,16 +10,17 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+
 	"github.com/gardener/docforge/pkg/api"
 	"github.com/gardener/docforge/pkg/markdown"
 	"github.com/gardener/docforge/pkg/resourcehandlers"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 	"k8s.io/klog/v2"
-	"net/url"
-	"path"
-	"strings"
-	"sync"
 )
 
 var (
@@ -591,7 +592,7 @@ func (f *frontmatterProcessor) getNodeTitle() string {
 	if f.node.Parent() != nil && f.nodeIsIndexFile(f.node.Name) {
 		title = f.node.Parent().Name
 	}
-	title = strings.TrimRight(title, ".md")
+	title = strings.TrimSuffix(title, ".md")
 	title = strings.ReplaceAll(title, "_", " ")
 	title = strings.ReplaceAll(title, "-", " ")
 	title = strings.Title(title)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug with the document titles.
With the previous function if we try to parse `managed_seed` , the function returns `managed_see`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The bug where the last letter of the node names is sometimes truncated is fixed
```
