### PR TITLE
Change base image from alpine to distroless and update go version to 1.17.12

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,11 +23,11 @@ docforge:
                 build: ~
     steps:
       check:
-        image: "golang:1.17.2"
+        image: "golang:1.17.12"
       test:
-        image: "golang:1.17.2"
+        image: "golang:1.17.12"
       build:
-        image: "golang:1.17.2"
+        image: "golang:1.17.12"
         output_dir: "binary"
       integration-test:
         image: "eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable"
@@ -42,7 +42,7 @@ docforge:
         pull-request: ~
       steps:
         docs-gen:
-          image: "golang:1.17.2"
+          image: "golang:1.17.12"
           inputs:
             BINARY_PATH: 'binary_path'
           depends:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1
+FROM gcr.io/distroless/static-debian11:nonroot
 
-COPY bin/rel/docforge-linux-amd64 /usr/local/bin/docforge
+COPY bin/rel/docforge-linux-amd64 /docforge
 
 WORKDIR /
+
+ENTRYPOINT [ "/docforge" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image for `docforge` container from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the image.

It also updates go version to `1.17.12`.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Docforge is now built using go version `1.17.12`.
```
```noteworthy user
Docforge now uses `distroless` as a base container image.
```