### PR TITLE
Build Multi-Arch Images

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -45,7 +45,7 @@ fi
 VERSION="$(cat "${VERSION_FILE}")"
 
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux/amd64, windows/386 and darwin/amd64 architectures and without CGO enablement.
+# to build for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 and windows/386 architectures and without CGO enablement.
 if [[ -z "$LOCAL_BUILD" ]]; then
   echo "Building docforge ${BINARY_PATH}/rel/docforge-linux-amd64"
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
@@ -55,11 +55,27 @@ if [[ -z "$LOCAL_BUILD" ]]; then
     -ldflags "-w -X github.com/gardener/docforge/pkg/version.Version=${VERSION}" \
     cmd/*.go
 
+  echo "Building docforge ${BINARY_PATH}/rel/docforge-linux-arm64"
+  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+    -a \
+    -v \
+    -o "${BINARY_PATH}/rel/docforge-linux-arm64" \
+    -ldflags "-w -X github.com/gardener/docforge/pkg/version.Version=${VERSION}" \
+    cmd/*.go
+
   echo "Building docforge ${BINARY_PATH}/rel/docforge-darwin-amd64"
   CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build \
     -a \
     -v \
     -o "${BINARY_PATH}/rel/docforge-darwin-amd64" \
+    -ldflags "-w -X github.com/gardener/docforge/pkg/version.Version=${VERSION}" \
+    cmd/*.go
+
+  echo "Building docforge ${BINARY_PATH}/rel/docforge-darwin-arm64"
+  CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build \
+    -a \
+    -v \
+    -o "${BINARY_PATH}/rel/docforge-darwin-arm64" \
     -ldflags "-w -X github.com/gardener/docforge/pkg/version.Version=${VERSION}" \
     cmd/*.go
 

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -11,6 +11,10 @@ docforge:
         inject_effective_version: true
       component_descriptor: ~
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           docforge:
             registry: "gcr-readwrite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@
 
 FROM gcr.io/distroless/static-debian11:nonroot
 
-COPY bin/rel/docforge-linux-amd64 /docforge
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY bin/rel/docforge-${TARGETOS}-${TARGETARCH} /docforge
 
 WORKDIR /
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR builds `arm64` binaries for `Linux` and `Darwin`.
Additionally, the the CI pipeline publishes multi-arch images with support for linux/amd64 and linux/arm64 now.

**Which issue(s) this PR fixes**:
Fixes #280 

**Special notes for your reviewer**:
If I understood `.ci/update-release.py` script correctly the new binaries should be added to the release automatically.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Docforge release includes docforge binaries for `arm64` architecture on `Linux` and `Darwin` now.
Docker images are published with multi-arch support for `linux/amd64` and `linux/arm64` now.
```
