### PR TITLE
Update testmachinery image location

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -34,7 +34,7 @@ docforge:
         image: "golang:1.20.0"
         output_dir: "binary"
       integration-test:
-        image: "eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable"
+        image: "europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run:stable"
       check-manifest:
         image: "eu.gcr.io/gardener-project/gardener-website-generator:stable"
   jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
With gardener/test-infra#479, testmachinery images are published to a new location.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
