### PR TITLE
Using go1.21 in pipeline_definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -27,11 +27,11 @@ docforge:
                 build: ~
     steps:
       check:
-        image: "golang:1.20.0"
+        image: "golang:1.21.0"
       test:
-        image: "golang:1.20.0"
+        image: "golang:1.21.0"
       build:
-        image: "golang:1.20.0"
+        image: "golang:1.21.0"
         output_dir: "binary"
       integration-test:
         image: "europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run:stable"
@@ -46,7 +46,7 @@ docforge:
         pull-request: ~
       steps:
         docs-gen:
-          image: "golang:1.20.0"
+          image: "golang:1.21.0"
           inputs:
             BINARY_PATH: 'binary_path'
           depends:


### PR DESCRIPTION
**What this PR does / why we need it**:
Using go1.21 in pipeline_definitions

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
NONE
```
