### PR TITLE
Publish component descriptor and image to GAR instead of GCR

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,7 +9,8 @@ docforge:
       version:
         preprocess: "inject-commit-hash"
         inject_effective_version: true
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: "europe-docker.pkg.dev/gardener-project/snapshots"
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -18,7 +19,7 @@ docforge:
         dockerimages:
           docforge:
             registry: "gcr-readwrite"
-            image: "eu.gcr.io/gardener-project/docforge"
+            image: "europe-docker.pkg.dev/gardener-project/snapshots/docforge"
             dockerfile: "Dockerfile"
             inputs:
               repos:
@@ -57,6 +58,23 @@ docforge:
       traits:
         version:
           preprocess: "finalize"
+        component_descriptor:
+          ocm_repository: "europe-docker.pkg.dev/gardener-project/releases"
+        publish:
+          oci-builder: docker-buildx
+          platforms:
+          - linux/amd64
+          - linux/arm64
+          dockerimages:
+            docforge:
+              registry: "gcr-readwrite"
+              image: "europe-docker.pkg.dev/gardener-project/releases/docforge"
+              dockerfile: "Dockerfile"
+              inputs:
+                repos:
+                  source: ~
+                steps:
+                  build: ~
         release:
           nextversion: "bump_minor"
         slack:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, no OCM repository is specified for the component-descriptor traits. Hence, a standard repository is being used which does not match the desired one. Also, the `docforge` image is still being published to Google Container Registry (GCR), which is deprecated. That's why, this change sets the target repository in both cases to `europe-docker.pkg.dev/gardener-project/(snapshots|releases)`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
