### PR TITLE
Fix: rm _path suffix from input names and env vars

### DIFF
--- a/.ci/docs-gen
+++ b/.ci/docs-gen
@@ -18,15 +18,15 @@ if [[ -z "${SOURCE_PATH}" ]]; then
   SOURCE_PATH="$(${READLINK_BIN} -f "$(dirname "${0}")/..")"
 fi
 
-if [[ -z "${BINARY_PATH}" ]]; then
-  BINARY_PATH="${SOURCE_PATH}/bin"
+if [[ -z "${BINARY}" ]]; then
+  BINARY="${SOURCE_PATH}/bin"
 else
-  BINARY_PATH="${BINARY_PATH}/bin"
+  BINARY="${BINARY}/bin"
 fi
 
-if [[ ! -d "${BINARY_PATH}/rel" ]]; then
-  echo "${BINARY_PATH}/rel does not exist. Forgot to build the binaries before running this?"
+if [[ ! -d "${BINARY}/rel" ]]; then
+  echo "${BINARY}/rel does not exist. Forgot to build the binaries before running this?"
   exit 1
 fi
 
-"$BINARY_PATH/rel/${binary}" gen-cmd-docs -d "$SOURCE_PATH/docs/cmd-ref"
+"$BINARY/rel/${binary}" gen-cmd-docs -d "$SOURCE_PATH/docs/cmd-ref"

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -51,7 +51,7 @@ docforge:
         docs-gen:
           image: "golang:1.21.0"
           inputs:
-            BINARY_PATH: 'binary_path'
+            BINARY: "binary"
           depends:
           - build
     release:
@@ -87,6 +87,6 @@ docforge:
         update-release:
           execute: 'update-release.py'
           inputs:
-            BINARY_PATH: 'binary_path'
+            BINARY: "binary"
           depends:
           - release

--- a/.ci/update-release.py
+++ b/.ci/update-release.py
@@ -14,7 +14,7 @@ VERSION_FILE_NAME='VERSION'
 
 repo_owner_and_name = util.check_env('SOURCE_GITHUB_REPO_OWNER_AND_NAME')
 repo_dir = util.check_env('MAIN_REPO_DIR')
-output_dir = util.check_env('BINARY_PATH')
+output_dir = util.check_env('BINARY')
 
 repo_owner, repo_name = repo_owner_and_name.split('/')
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since recently, the `_path` suffix is not appended to step outputs anymore ([ref](https://github.com/gardener/cc-utils/commit/7dfb6afed52e9a372640362174236992d3f74c64)). Hence, this change is a required follow-up for the changed behaviour.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
