### PR TITLE
Remove check-manifest and docs-gen steps

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -38,8 +38,6 @@ docforge:
         output_dir: "binary"
       integration-test:
         image: "europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run:stable"
-      check-manifest:
-        image: "europe-docker.pkg.dev/gardener-project/releases/gardener-website-generator:stable"
   jobs:
     head-update:
       traits:
@@ -47,13 +45,6 @@ docforge:
     pull-request:
       traits:
         pull-request: ~
-      steps:
-        docs-gen:
-          image: "golang:1.21.0"
-          inputs:
-            BINARY: "binary"
-          depends:
-          - build
     release:
       traits:
         version:


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove check-manifest and docs-gen steps

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/docforge/issues/339

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
