### PR TITLE
Introduce task make target that runs tests before committing the provided message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,7 @@ check-manifest:
 .PHONY: generate
 generate:
 	@go generate ./...
+
+.PHONY: task
+task:
+	@./task.sh "$(m)"

--- a/task.sh
+++ b/task.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "$1" ]]; then
+    echo "Please provide a commit message"
+    exit 1
+fi
+created_files=$(git ls-files --others --exclude-standard)
+modified_files=$(git diff --name-only)
+staged_files=$(git diff --cached --name-only)
+echo -e "-------------"
+if [[ -n "${created_files}${modified_files}" ]]; then 
+    echo -e "\033[1;31mChanges:\033[0m"
+    echo -e "${created_files}${created_files:+\n}${modified_files}"
+    echo 
+fi
+if [[ -n "$staged_files" ]]; then
+    echo -e "\033[1;32mStaged changes:\033[0m"
+    echo -e "$staged_files"
+    echo
+fi
+echo -e "-------------"
+echo 
+if [[ -n "${created_files}${modified_files}" ]]; then
+    echo "Please stage all files before running this command"
+    exit 1
+fi
+if [[ -z "$staged_files" ]]; then
+    echo "No files are staged"
+    exit 1
+fi
+
+echo "Running tests:"
+.ci/test > /dev/null 2>&1
+echo "Running integration tests:"
+.ci/integration-test > /dev/null 2>&1
+
+commit_message="[task] $1"
+git commit -m"$commit_message"


### PR DESCRIPTION
**What this PR does / why we need it**:
Inspired by [Use git tactically](https://stackoverflow.blog/2022/12/19/use-git-tactically/#h1-941b6d3674fd0) this PR introduces `make task m="commit message"` that ensures the code compiles and runs tests before committing all the added files with the given commit message. These are the biggest benefits from `make task`:
- There are no commits that represent a partial functionality state. So when going over commits the reviewer doesn't need to keep mental track of previous partial states. That way all he needs to focus on is whether the current commit does what is described to do from the commit message
- This encourages people to split big tasks into smaller subtasks that are achievable and reviewable
- This discourages doing huge tasks that don't seem to be achievable through incremental steps (avoiding sunk cost fallacy)

This PR's commit is added using `make task`
```
$  make task m="Introduce task make target that runs tests before commiting the provided message"
-------------
Staged changes:
Makefile
task.sh

-------------

Running tests:
Running integration tests:
[introduce-make-task 672b363] [task] Introduce task make target that runs tests before commiting the provided message
 2 files changed, 44 insertions(+)
 create mode 100755 task.sh
```

**Note:** Authors can still create normal commits. Just doing commits through `make task` adds the `[task]` prefix to the commit message that lets the reviewer know that the given commit is done through `make task` and represents a complete state

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
New make target `task` was added for aiding in creating micro-commits
```
