### PR TITLE
Remove defaulting of files to `md`. `fileTree` won't load files without md suffix

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -188,21 +188,17 @@ func resolveRelativeLinks(node *Node, _ *Node, manifest *Node, r registry.Interf
 }
 
 func extractFilesFromNode(node *Node, parent *Node, manifest *Node, r registry.Interface) error {
-	switch node.Type {
-	case "file":
-		if !strings.HasSuffix(node.File, ".md") {
-			node.File += ".md"
-		}
-	case "fileTree":
-		files, err := r.Tree(node.FileTree)
-		if err != nil {
-			return err
-		}
-		if err := constructNodeTree(files, node, parent); err != nil {
-			return err
-		}
-		removeNodeFromParent(node, parent)
+	if node.Type != "fileTree" {
+		return nil
 	}
+	files, err := r.Tree(node.FileTree)
+	if err != nil {
+		return err
+	}
+	if err := constructNodeTree(files, node, parent); err != nil {
+		return err
+	}
+	removeNodeFromParent(node, parent)
 	return nil
 }
 
@@ -222,7 +218,7 @@ func constructNodeTree(files []string, node *Node, parent *Node) error {
 	pathToDirNode[node.Path] = parent
 	for _, file := range files {
 		extension := path.Ext(file)
-		if extension != ".md" && extension != "" {
+		if extension != ".md" {
 			continue
 		}
 		shouldExclude := false
@@ -245,9 +241,6 @@ func constructNodeTree(files []string, node *Node, parent *Node) error {
 			return err
 		}
 		fileName := path.Base(file)
-		if !strings.HasSuffix(fileName, ".md") {
-			fileName = fileName + ".md"
-		}
 		filePath := path.Join(node.Path, path.Dir(file))
 		parentNode := getParrentNode(pathToDirNode, filePath)
 		parentNode.Structure = append(parentNode.Structure, &Node{

--- a/pkg/manifest/tests/manifests/index_md_with_properties.yaml
+++ b/pkg/manifest/tests/manifests/index_md_with_properties.yaml
@@ -21,7 +21,7 @@ structure:
       # _index.md with full path
       - file: https://github.com/gardener/docforge/blob/master/contents/website/blog/2024/_index.md
     # renamed _index.md file
-    - file: renamed
+    - file: renamed.md
       source: https://github.com/gardener/docforge/blob/master/contents/website/blog/2024/_index.md
     # importing _index.md from filetree
     - fileTree: /contents/website

--- a/pkg/manifest/tests/manifests/multisource.yaml
+++ b/pkg/manifest/tests/manifests/multisource.yaml
@@ -1,5 +1,5 @@
 structure:
-- file: testo
+- file: testo.md
   multiSource:
   - /contents/blogs/2024/foo.md
   - /contents/blogs/2024/two.md


### PR DESCRIPTION
**What this PR does / why we need it**:
Defaulting files to `.md` does not provide any value so let's remove it at it is an implicit behavior. Files without extension were not skipped as they were defaulted to `.md`. When we don't have the defaulting logic let's just skip all files that are not `.md`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Remove defaulting of files to `md`. `fileTree` won't load files without `md `suffix
```
