### PR TITLE
Fix issue in matching `gardener/gardener...` to `gardener/gardener/`

### DIFF
--- a/pkg/registry/repositoryhost/local.go
+++ b/pkg/registry/repositoryhost/local.go
@@ -106,7 +106,7 @@ func (l *Local) Tree(resource URL) ([]string, error) {
 
 // Accept if the link has the same url prefix as defined
 func (l *Local) Accept(link string) bool {
-	return strings.HasPrefix(link, l.urlPrefix)
+	return strings.HasPrefix(link, strings.TrimSuffix(l.urlPrefix, "/")+"/")
 }
 
 // Read a resource content at uri into a byte array from file system


### PR DESCRIPTION
**What this PR does / why we need it**:
`Local.Accept()` no longer matches `gardener/gardener/` and any repository with `gardener/gardener-<rest of the repo name>/`

**Which issue(s) this PR fixes**:
Fixes #345

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Fixed resourceMapping for mappings with similar prefixes as gardener/gardener.
```
