### PR TITLE
Add `resource-website-path`

### DIFF
--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -67,7 +67,7 @@ func exec(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	docProcessor, docTasks, err := document.New(config.DocumentWorkersCount, config.FailFast, reactorWG, documentNodes, config.ResourcesPath, dScheduler, v, rhRegistry, config.Hugo, config.Writer, config.SkipLinkValidation)
+	docProcessor, docTasks, err := document.New(config.DocumentWorkersCount, config.FailFast, reactorWG, documentNodes, config.ResourcesWebsitePath, dScheduler, v, rhRegistry, config.Hugo, config.Writer, config.SkipLinkValidation)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/flags.go
+++ b/cmd/app/flags.go
@@ -24,6 +24,10 @@ func configureFlags(command *cobra.Command) {
 		"Resources download path.")
 	_ = vip.BindPFlag("resources-download-path", command.Flags().Lookup("resources-download-path"))
 
+	command.Flags().String("resources-website-path", "__resources",
+		"The path in the website where resources will be accessed through.")
+	_ = vip.BindPFlag("resources-website-path", command.Flags().Lookup("resources-website-path"))
+
 	command.Flags().StringToString("github-oauth-token-map", map[string]string{},
 		"GitHub personal tokens authorizing read access from repositories per GitHub instance. Note that if the GitHub token is already provided by `github-oauth-token` it will be overridden by it.")
 	_ = vip.BindPFlag("github-oauth-token-map", command.Flags().Lookup("github-oauth-token-map"))

--- a/cmd/app/initilization.go
+++ b/cmd/app/initilization.go
@@ -107,7 +107,7 @@ func getReactorConfig(options Options, hugo hugo.Hugo, rhs []repositoryhost.Inte
 		Hugo: config.Hugo.Enabled,
 	}
 	config.ResourceDownloadWriter = &writers.FSWriter{
-		Root: filepath.Join(config.DestinationPath, config.ResourcesPath),
+		Root: filepath.Join(config.DestinationPath, config.ResourcesDownloadPath),
 	}
 
 	if len(config.GhInfoDestination) > 0 {

--- a/cmd/app/types.go
+++ b/cmd/app/types.go
@@ -17,7 +17,8 @@ type Options struct {
 	ValidationWorkersCount       int      `mapstructure:"validation-workers"`
 	FailFast                     bool     `mapstructure:"fail-fast"`
 	DestinationPath              string   `mapstructure:"destination"`
-	ResourcesPath                string   `mapstructure:"resources-download-path"`
+	ResourcesDownloadPath        string   `mapstructure:"resources-download-path"`
+	ResourcesWebsitePath         string   `mapstructure:"resources-website-path"`
 	ManifestPath                 string   `mapstructure:"manifest"`
 	ResourceDownloadWorkersCount int      `mapstructure:"download-workers"`
 	GhInfoDestination            string   `mapstructure:"github-info-destination"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a distinct `resource-website-path` flag that is the path in the website URL where resources will be accessed

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
