### PR TITLE
Add `gochecknoglobals` linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,11 @@ task:
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run --enable gochecknoglobals
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+	$(GOLANGCI_LINT) run --fix --enable gochecknoglobals
 
 
 ##@ Dependencies
@@ -122,11 +122,17 @@ $(LOCALBIN):
 
 GOLANGCI_LINT_VERSION ?= v1.61.0
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+GOCHECKNOGLOBALS := 4d63.com/gochecknoglobals
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+.PHONY: gochecknoglobals
+gochecknoglobals: $(GOCHECKNOGLOBALS) ## Download gochecknoglobals locally if necessary.
+$(GOCHECKNOGLOBALS): $(LOCALBIN)
+    $(call go-install-tool,$(GOCHECKNOGLOBALS),latest)
 
 define go-install-tool
 @[ -f $(1) ] || { \


### PR DESCRIPTION
**What this PR does / why we need it**:
The linter adds a check for global variables since they can result in code that is harder to understand and they can carry side-effects through an application that aren’t contained by the functions that use or rely on them.

**Which issue(s) this PR fixes**:
Fixes #336 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
`make lint` now checks for global variables.
```
