### PR TITLE
Temporary fix bug by increasing buffer size

### DIFF
--- a/pkg/workers/taskqueue/taskqueue.go
+++ b/pkg/workers/taskqueue/taskqueue.go
@@ -18,7 +18,7 @@ import (
 const (
 	maxWorkerSize = 100
 	minWorkerSize = 1
-	bufferSize    = 1000
+	bufferSize    = 4000
 )
 
 // Interface can Start/Stop the queue and see its status


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug where when there are more than 1000 files docforge gets stuck

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
