### PR TITLE
Fix checking out empty `current_branch`

### DIFF
--- a/.ci/e2e
+++ b/.ci/e2e
@@ -73,5 +73,9 @@ rm -rf "${PR_content}/__resources"
 diff -r "$content" "$PR_content"
 
 pushd "$docforge_repo_path"
-git checkout "$current_branch"
+if [[ -n "$current_branch" ]]; then
+    git checkout "$current_branch"
+else
+    echo "current_branch is empty"
+fi
 mv "VERSION_PR" "VERSION"


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
