### PR TITLE
Add `hugo-structural-dirs` flag

### DIFF
--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -7,6 +7,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/gardener/docforge/pkg/manifest"
@@ -29,6 +31,12 @@ func exec(ctx context.Context, vip *viper.Viper) error {
 	)
 
 	err := vip.Unmarshal(&options)
+	existsPath := slices.ContainsFunc(options.HugoStructuralDirs, func(dir string) bool {
+		return strings.Contains(dir, "/")
+	})
+	if existsPath {
+		return fmt.Errorf("hugo-structural-dirs contains a path instead a directory name")
+	}
 	klog.Infof("Manifest: %s", options.ManifestPath)
 	localRH := []repositoryhost.Interface{}
 	for resource, mapped := range options.ResourceMappings {

--- a/cmd/app/flags.go
+++ b/cmd/app/flags.go
@@ -69,6 +69,10 @@ func configureFlags(command *cobra.Command, vip *viper.Viper) {
 		"Rewrites the relative links of documentation files to root-relative where possible.")
 	_ = vip.BindPFlag("hugo-base-url", command.Flags().Lookup("hugo-base-url"))
 
+	command.Flags().StringSlice("hugo-structural-dirs", []string{},
+		"List of directories that are part of the hugo bundle structure and should not be included in the resolved links.")
+	_ = vip.BindPFlag("hugo-structural-dirs", command.Flags().Lookup("hugo-structural-dirs"))
+
 	command.Flags().StringSlice("hugo-section-files", []string{"readme.md", "README.md"},
 		"When building a Hugo-compliant documentation bundle, files with filename matching one form this list (in that order) will be renamed to _index.md. Only useful with --hugo=true")
 	_ = vip.BindPFlag("hugo-section-files", command.Flags().Lookup("hugo-section-files"))

--- a/cmd/hugo/option.go
+++ b/cmd/hugo/option.go
@@ -6,8 +6,9 @@ package hugo
 
 // Hugo is the configuration options for creating HUGO implementations
 type Hugo struct {
-	Enabled        bool     `mapstructure:"hugo"`
-	PrettyURLs     bool     `mapstructure:"hugo-pretty-urls"`
-	BaseURL        string   `mapstructure:"hugo-base-url"`
-	IndexFileNames []string `mapstructure:"hugo-section-files"`
+	Enabled            bool     `mapstructure:"hugo"`
+	PrettyURLs         bool     `mapstructure:"hugo-pretty-urls"`
+	BaseURL            string   `mapstructure:"hugo-base-url"`
+	IndexFileNames     []string `mapstructure:"hugo-section-files"`
+	HugoStructuralDirs []string `mapstructure:"hugo-structural-dirs"`
 }

--- a/pkg/workers/linkresolver/link_resolving.go
+++ b/pkg/workers/linkresolver/link_resolving.go
@@ -68,6 +68,9 @@ func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.N
 	if l.Hugo.Enabled {
 		websiteLink = strings.ToLower(destinationNode.HugoPrettyPath())
 	}
+	for _, structuralDir := range l.Hugo.HugoStructuralDirs {
+		websiteLink = strings.TrimPrefix(websiteLink, structuralDir+"/")
+	}
 	return fmt.Sprintf("/%s/%s", path.Join(l.Hugo.BaseURL, websiteLink), destinationResource.GetResourceSuffix()), nil
 }
 

--- a/pkg/workers/linkresolver/link_resolving_test.go
+++ b/pkg/workers/linkresolver/link_resolving_test.go
@@ -101,6 +101,13 @@ var _ = Describe("Document link resolving", func() {
 			Expect(err.Error()).To(ContainSubstring("no sutiable repository host"))
 		})
 
+		It("Resolves resource links containing hugo structural directory correctly", func() {
+			linkResolver.Hugo.HugoStructuralDirs = []string{"content"}
+			newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/file.md", node, source)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newLink).To(Equal("/baseURL/docs/file/"))
+		})
+
 		Context("Resolving URL from linkResolution", func() {
 			It("Resolves it correctly", func() {
 				By("Node having no linkResolution should map to closest node")

--- a/pkg/workers/linkresolver/tests/baseline.yaml
+++ b/pkg/workers/linkresolver/tests/baseline.yaml
@@ -28,3 +28,8 @@ structure:
       multiSource:
       - https://github.com/gardener/docforge/blob/master/clickhere2.md
       - https://github.com/gardener/docforge/blob/master/clickhere.md
+- dir: content
+  structure:
+  - dir: docs
+    structure:
+    - file: https://github.com/gardener/docforge/blob/master/file.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements `hugo-structural-dirs` flag. It is a list of directories that are part of the hugo bundle structure and should not be included in the resolved links.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
