### PR TITLE
Replace `github-oauth-token-map` with `github-oauth-env-map`

### DIFF
--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -109,7 +109,7 @@ function cleanup {
 # Run docforge command with Git handler
 echo
 echo "Run ${docforge_bin}"
-DOCFORGE_CONFIG="$int_test_config_file" ${docforge_bin} --github-oauth-token-map "github.com=${GIT_OAUTH_TOKEN}"
+TOKEN="$GIT_OAUTH_TOKEN" DOCFORGE_CONFIG="$int_test_config_file" ${docforge_bin} --github-oauth-env-map "github.com=TOKEN"
 
 #Remove untested metadata keys
 removeUntestedKeysFromMetadata "${int_test_expected_metadata_dir}"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ go get github.com/gardener/docforge
 
 ## Usage
 
-> **GitHub API Disclaimer**: The docforge tool can pull material from GitHub and it will use the GitHub API for that. The API has certain usage [rt limits](https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rt-limiting) and they are very easy to hit for unauthenticated requests - up to 60 requests per hour per originating IP as of the time of this writing. It is highly recommended to create a GitHub personal token ([GitHub Account > Settings > Developer Settings > Personal access tokens](https://github.com/settings/tokens)) and supply it to `docforge` with the `--github-oauth-token-map` flag.
+> **GitHub API Disclaimer**: The docforge tool can pull material from GitHub and it will use the GitHub API for that. The API has certain usage [rt limits](https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rt-limiting) and they are very easy to hit for unauthenticated requests - up to 60 requests per hour per originating IP as of the time of this writing. It is highly recommended to create a GitHub personal token, export it using an environment variable ([GitHub Account > Settings > Developer Settings > Personal access tokens](https://github.com/settings/tokens)) and supply it to `docforge` with the `--github-oauth-env-map` flag.
 
 
 ### Basics
@@ -81,10 +81,10 @@ To create a documentation material bundle, it is necessary to describe it in a m
 Assuming that:
 - the **destination** where the forged bundle will appear is `/tmp/docforge-docs`, and 
 - the **manifest** file is [example/simple/00.yaml](example/simple/00.yaml), and
-- the **GitHub token map** Comma separated strings in format \<host\>=\<user\>:\<token\> 
+- the **GitHub env map** Comma separated strings in format \<host\>=\<token_env_var\> 
 the command to forge the bundle is:
 ```sh
-docforge -d /tmp/docforge-docs -f example/simple/00.yaml --github-oauth-token-map  github.com=<user>:<token>,...
+docforge -d /tmp/docforge-docs -f example/simple/00.yaml --github-oauth-env-map  github.com=GITHUB_TOKEN,...
 ```
 
 All avaliable flags for the build command can be seen [here](docs/cmd-ref/docforge.md)

--- a/cmd/app/flags.go
+++ b/cmd/app/flags.go
@@ -29,9 +29,9 @@ func configureFlags(command *cobra.Command, vip *viper.Viper) {
 		"The path in the website where resources will be accessed through.")
 	_ = vip.BindPFlag("resources-website-path", command.Flags().Lookup("resources-website-path"))
 
-	command.Flags().StringToString("github-oauth-token-map", map[string]string{},
-		"GitHub personal tokens authorizing read access from repositories per GitHub instance. Note that if the GitHub token is already provided by `github-oauth-token` it will be overridden by it.")
-	_ = vip.BindPFlag("github-oauth-token-map", command.Flags().Lookup("github-oauth-token-map"))
+	command.Flags().StringToString("github-oauth-env-map", map[string]string{},
+		"Map between GitHub instances and ENV var names that will be used for access tokens")
+	_ = vip.BindPFlag("github-oauth-env-map", command.Flags().Lookup("github-oauth-env-map"))
 
 	command.Flags().String("github-info-destination", "",
 		"If specified, docforge will download also additional github info for the files from the documentation structure into this destination.")

--- a/cmd/app/initilization.go
+++ b/cmd/app/initilization.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -26,7 +27,12 @@ import (
 func initRepositoryHosts(ctx context.Context, o repositoryhost.InitOptions) ([]repositoryhost.Interface, error) {
 	var rhs []repositoryhost.Interface
 	var errs *multierror.Error
-	for host, oAuthToken := range o.Credentials {
+
+	for host, envVar := range o.EnvCredentials {
+		oAuthToken := os.Getenv(envVar)
+		if oAuthToken == "" {
+			return nil, fmt.Errorf("%s's OAUTH ENV variable is empty", host)
+		}
 		instance := host
 		if !strings.HasPrefix(instance, "https://") && !strings.HasPrefix(instance, "http://") {
 			instance = "https://" + instance

--- a/pkg/registry/repositoryhost/repository_host.go
+++ b/pkg/registry/repositoryhost/repository_host.go
@@ -53,7 +53,7 @@ type Interface interface {
 // InitOptions options for the resource handler
 type InitOptions struct {
 	CacheHomeDir     string            `mapstructure:"cache-dir"`
-	Credentials      map[string]string `mapstructure:"github-oauth-token-map"`
+	EnvCredentials   map[string]string `mapstructure:"github-oauth-env-map"`
 	ResourceMappings map[string]string `mapstructure:"resourceMappings"`
 	Hugo             bool              `mapstructure:"hugo"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Now Github credentials can only be provided through env vars for improved security

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
