### PR TITLE
Add a trailing slash only on hugo `.md` files

### DIFF
--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -2,6 +2,7 @@ package link
 
 import "net/url"
 
+// Build builds a link given its elements
 func Build(elem ...string) (string, error) {
 	if len(elem) == 0 {
 		return "", nil
@@ -9,6 +10,7 @@ func Build(elem ...string) (string, error) {
 	return url.JoinPath(elem[0], elem[1:]...)
 }
 
+// MustBuild builds a link given its elements and panics if it fails
 func MustBuild(elem ...string) string {
 	res, err := Build(elem...)
 	if err != nil {

--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -1,0 +1,18 @@
+package link
+
+import "net/url"
+
+func Build(elem ...string) (string, error) {
+	if len(elem) == 0 {
+		return "", nil
+	}
+	return url.JoinPath(elem[0], elem[1:]...)
+}
+
+func MustBuild(elem ...string) string {
+	res, err := Build(elem...)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}

--- a/pkg/link/link_test.go
+++ b/pkg/link/link_test.go
@@ -1,0 +1,43 @@
+package link_test
+
+import (
+	"testing"
+
+	_ "embed"
+
+	"github.com/gardener/docforge/pkg/link"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestLink(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Link Suite")
+}
+
+var _ = Describe("Join", func() {
+	DescribeTable("should join link path elements correctly",
+		func(elements []string, expected string) {
+			result := link.MustBuild(elements...)
+			Expect(result).To(Equal(expected))
+		},
+		Entry("joins multiple path elements", []string{"a", "b", "c"}, "a/b/c"),
+		Entry("collapses repeating slashes", []string{"a/", "//b", "c"}, "a/b/c"),
+		Entry("handles empty elements", []string{"a", "", "c"}, "a/c"),
+		Entry("returns an empty string when no elements are provided", []string{}, ""),
+		Entry("joins elements with a leading slash", []string{"/", "foo"}, "/foo"),
+		Entry("joins elements with leading and trailing slashes", []string{"/a", "b/"}, "/a/b/"),
+		Entry("joins elements with leading and trailing slashes", []string{"/", "foo/"}, "/foo/"),
+		Entry("joins elements with leading and trailing slashes", []string{"/", "foo", "/"}, "/foo/"),
+	)
+
+	DescribeTable("should join URL elements correctly",
+		func(elements []string, expected string) {
+			result := link.MustBuild(elements...)
+			Expect(result).To(Equal(expected))
+		},
+		Entry("joins URL", []string{"https://", "foo", "bar", "baz"}, "https://foo/bar/baz"),
+		Entry("joins URL with a trailing slash", []string{"https://", "foo", "bar", "baz/"}, "https://foo/bar/baz/"),
+	)
+})

--- a/pkg/manifest/node.go
+++ b/pkg/manifest/node.go
@@ -56,6 +56,9 @@ func (n *Node) NodePath() string {
 // HugoPrettyPath returns hugo pretty path
 func (n *Node) HugoPrettyPath() string {
 	name := n.Name()
+	if !strings.HasSuffix(name, ".md") {
+		return path.Join(n.Path, name)
+	}
 	name = strings.TrimSuffix(name, ".md")
 	name = strings.TrimSuffix(name, "_index")
 	return path.Join(n.Path, name) + "/"

--- a/pkg/workers/linkresolver/link_resolving.go
+++ b/pkg/workers/linkresolver/link_resolving.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/gardener/docforge/cmd/hugo"
+	"github.com/gardener/docforge/pkg/link"
 	"github.com/gardener/docforge/pkg/manifest"
 	"github.com/gardener/docforge/pkg/registry"
 	"github.com/gardener/docforge/pkg/registry/repositoryhost"
@@ -71,7 +72,10 @@ func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.N
 	for _, structuralDir := range l.Hugo.HugoStructuralDirs {
 		websiteLink = strings.TrimPrefix(websiteLink, structuralDir+"/")
 	}
-	return fmt.Sprintf("/%s/%s", path.Join(l.Hugo.BaseURL, websiteLink), destinationResource.GetResourceSuffix()), nil
+	if destinationResource.GetResourceSuffix() != "" {
+		return fmt.Sprintf("/%s/%s", path.Join(l.Hugo.BaseURL, websiteLink), destinationResource.GetResourceSuffix()), nil
+	}
+	return fmt.Sprintf("/%s", link.MustBuild(l.Hugo.BaseURL, websiteLink)), nil
 }
 
 func (l *LinkResolver) resolveDestinationNode(destinationResourceURL string, node *manifest.Node) (*manifest.Node, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
For example `/html/foo.html` should not receive a trailing `/` when hugo is enabled

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
