### PR TITLE
Add docforge_config.yaml for e2e test

### DIFF
--- a/test/e2e/docforge_config.yaml
+++ b/test/e2e/docforge_config.yaml
@@ -1,0 +1,20 @@
+manifest: https://github.com/gardener/documentation/blob/master/.docforge/hugo.yaml
+destination: test/e2e/hugo
+hugo: true
+hugo-structural-dirs:
+- content
+- static
+content-files-formats:
+- ".md"
+- ".html"
+- ".js"
+- ".scss"
+- ".css"
+- ".toml"
+- ".json"
+- ".png"
+- ".svg"
+resources-download-path: content/__resources
+github-oauth-env-map:
+  "github.com": GITHUB_OAUTH_TOKEN
+skip-link-validation: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds config file in order for https://github.com/gardener/docforge/pull/393 to be able to checkout master and check diffs.

**Which issue(s) this PR fixes**:
Part of #389

**Special notes for your reviewer**:
This PR is a prerequisite for https://github.com/gardener/docforge/pull/393

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
