### PR TITLE
Use `pkg/link` when building links for consistency

### DIFF
--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -1,11 +1,18 @@
 package link
 
-import "net/url"
+import (
+	"fmt"
+	"net/url"
+)
 
 // Build builds a link given its elements
 func Build(elem ...string) (string, error) {
 	if len(elem) == 0 {
 		return "", nil
 	}
-	return url.JoinPath(elem[0], elem[1:]...)
+	jointPath, err := url.JoinPath(elem[0], elem[1:]...)
+	if err != nil {
+		return "", fmt.Errorf("failed to join paths: %w", err)
+	}
+	return url.QueryUnescape(jointPath)
 }

--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -3,6 +3,7 @@ package link
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // Build builds a link given its elements
@@ -14,5 +15,5 @@ func Build(elem ...string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to join paths: %w", err)
 	}
-	return url.QueryUnescape(jointPath)
+	return strings.ReplaceAll(strings.ReplaceAll(jointPath, "%3F", "?"), "%23", "#"), nil
 }

--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -12,6 +12,10 @@ func Build(elem ...string) (string, error) {
 		return "", nil
 	}
 	jointPath, err := url.JoinPath(elem[0], elem[1:]...)
+	// TODO Remove this after improvement in manifest.go
+	if jointPath == "" {
+		return ".", nil
+	}
 	if err != nil {
 		return "", fmt.Errorf("failed to join paths: %w", err)
 	}

--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -15,5 +15,9 @@ func Build(elem ...string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to join paths: %w", err)
 	}
-	return strings.ReplaceAll(strings.ReplaceAll(jointPath, "%3F", "?"), "%23", "#"), nil
+	escapedQuery, err := url.QueryUnescape(jointPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to unescape joint path: %w", err)
+	}
+	return strings.ReplaceAll(escapedQuery, " ", "%20"), nil
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -13,7 +13,8 @@ import (
 	"slices"
 	"strings"
 
-	link "github.com/gardener/docforge/pkg/link"
+	"github.com/gardener/docforge/pkg/link"
+	"github.com/gardener/docforge/pkg/must"
 	"github.com/gardener/docforge/pkg/registry"
 	"github.com/gardener/docforge/pkg/registry/repositoryhost"
 	"gopkg.in/yaml.v2"
@@ -328,7 +329,7 @@ func mergeFolders(node *Node, parent *Node, manifest *Node, _ registry.Interface
 func resolvePersonaFolders(node *Node, parent *Node, manifest *Node, _ registry.Interface, _ []string) error {
 	if node.Type == "dir" && (node.Dir == "development" || node.Dir == "operations" || node.Dir == "usage") {
 		for _, child := range node.Structure {
-			addPersonaAliasesForNode(child, node.Dir, link.MustBuild("/", node.HugoPrettyPath()))
+			addPersonaAliasesForNode(child, node.Dir, must.Succeed(link.Build("/", node.HugoPrettyPath())))
 		}
 		parent.Structure = append(parent.Structure, node.Structure...)
 		removeNodeFromParent(node, parent)

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -60,8 +60,8 @@ var _ = Describe("Manifest test", func() {
 				if expected[i].Frontmatter == nil {
 					expected[i].Frontmatter = map[string]interface{}{}
 				}
-				Expect(*files[i]).To(Equal(*expected[i]))
 			}
+			Expect(files).To(ConsistOf(expected))
 		},
 		Entry("covering _index.md use cases", "index_md_with_properties"),
 		Entry("covering directory merges", "merging"),

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -60,8 +60,8 @@ var _ = Describe("Manifest test", func() {
 				if expected[i].Frontmatter == nil {
 					expected[i].Frontmatter = map[string]interface{}{}
 				}
+				Expect(*files[i]).To(Equal(*expected[i]))
 			}
-			Expect(files).To(ConsistOf(expected))
 		},
 		Entry("covering _index.md use cases", "index_md_with_properties"),
 		Entry("covering directory merges", "merging"),

--- a/pkg/manifest/node.go
+++ b/pkg/manifest/node.go
@@ -7,7 +7,8 @@ package manifest
 import (
 	"strings"
 
-	link "github.com/gardener/docforge/pkg/link"
+	"github.com/gardener/docforge/pkg/link"
+	"github.com/gardener/docforge/pkg/must"
 	"gopkg.in/yaml.v3"
 )
 
@@ -50,18 +51,18 @@ func (n *Node) Name() string {
 // NodePath returns fully qualified name of this node
 // i.e. Node.Path + Node.Name
 func (n *Node) NodePath() string {
-	return link.MustBuild(n.Path, n.Name())
+	return must.Succeed(link.Build(n.Path, n.Name()))
 }
 
 // HugoPrettyPath returns hugo pretty path
 func (n *Node) HugoPrettyPath() string {
 	name := n.Name()
 	if !strings.HasSuffix(name, ".md") {
-		return link.MustBuild(n.Path, name)
+		return must.Succeed(link.Build(n.Path, name))
 	}
 	name = strings.TrimSuffix(name, ".md")
 	name = strings.TrimSuffix(name, "_index")
-	return link.MustBuild(n.Path, name, "/")
+	return must.Succeed(link.Build(n.Path, name, "/"))
 }
 
 // HasContent returns true if the node is a document node

--- a/pkg/manifest/node.go
+++ b/pkg/manifest/node.go
@@ -5,9 +5,9 @@
 package manifest
 
 import (
-	"path"
 	"strings"
 
+	link "github.com/gardener/docforge/pkg/link"
 	"gopkg.in/yaml.v3"
 )
 
@@ -50,18 +50,18 @@ func (n *Node) Name() string {
 // NodePath returns fully qualified name of this node
 // i.e. Node.Path + Node.Name
 func (n *Node) NodePath() string {
-	return path.Join(n.Path, n.Name())
+	return link.MustBuild(n.Path, n.Name())
 }
 
 // HugoPrettyPath returns hugo pretty path
 func (n *Node) HugoPrettyPath() string {
 	name := n.Name()
 	if !strings.HasSuffix(name, ".md") {
-		return path.Join(n.Path, name)
+		return link.MustBuild(n.Path, name)
 	}
 	name = strings.TrimSuffix(name, ".md")
 	name = strings.TrimSuffix(name, "_index")
-	return path.Join(n.Path, name) + "/"
+	return link.MustBuild(n.Path, name, "/")
 }
 
 // HasContent returns true if the node is a document node

--- a/pkg/registry/repositoryhost/resource_url.go
+++ b/pkg/registry/repositoryhost/resource_url.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/gardener/docforge/pkg/link"
 )
 
 var (
@@ -34,7 +36,7 @@ func RawURL(resourceURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("https://%s/%s/%s/raw/%s/%s", r.host, r.owner, r.repo, r.ref, r.resourcePath), nil
+	return link.Build("https://", r.host, r.owner, r.repo, "raw", r.ref, r.resourcePath)
 }
 
 // URL represents an repsource url
@@ -99,17 +101,17 @@ func new(resourceURL string) (*URL, error) {
 // String returns the full url
 func (r URL) String() string {
 	if r.resourcePath == "" {
-		return fmt.Sprintf("https://%s/%s/%s/%s/%s", r.host, r.owner, r.repo, r.resourceType, r.ref)
+		return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref)
 	}
-	return fmt.Sprintf("https://%s/%s/%s/%s/%s/%s%s", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath, r.resourceSuffix)
+	return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath+r.resourceSuffix)
 }
 
 // ResourceURL returns the resource url without resource suffix
 func (r URL) ResourceURL() string {
 	if r.resourcePath == "" {
-		return fmt.Sprintf("https://%s/%s/%s/%s/%s", r.host, r.owner, r.repo, r.resourceType, r.ref)
+		return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref)
 	}
-	return fmt.Sprintf("https://%s/%s/%s/%s/%s/%s", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath)
+	return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath)
 }
 
 // ReferenceURL returns the reference url object

--- a/pkg/registry/repositoryhost/resource_url.go
+++ b/pkg/registry/repositoryhost/resource_url.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gardener/docforge/pkg/link"
+	"github.com/gardener/docforge/pkg/must"
 )
 
 var (
@@ -101,17 +102,17 @@ func new(resourceURL string) (*URL, error) {
 // String returns the full url
 func (r URL) String() string {
 	if r.resourcePath == "" {
-		return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref)
+		return must.Succeed(link.Build("https://", r.host, r.owner, r.repo, r.resourceType, r.ref))
 	}
-	return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath+r.resourceSuffix)
+	return must.Succeed(link.Build("https://", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath+r.resourceSuffix))
 }
 
 // ResourceURL returns the resource url without resource suffix
 func (r URL) ResourceURL() string {
 	if r.resourcePath == "" {
-		return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref)
+		return must.Succeed(link.Build("https://", r.host, r.owner, r.repo, r.resourceType, r.ref))
 	}
-	return link.MustBuild("https://", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath)
+	return must.Succeed(link.Build("https://", r.host, r.owner, r.repo, r.resourceType, r.ref, r.resourcePath))
 }
 
 // ReferenceURL returns the reference url object

--- a/pkg/workers/document/document_worker.go
+++ b/pkg/workers/document/document_worker.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 
 	"github.com/gardener/docforge/cmd/hugo"
-	link "github.com/gardener/docforge/pkg/link"
+	"github.com/gardener/docforge/pkg/link"
 	"github.com/gardener/docforge/pkg/manifest"
 	"github.com/gardener/docforge/pkg/registry"
 	"github.com/gardener/docforge/pkg/registry/repositoryhost"

--- a/pkg/workers/linkresolver/link_resolving.go
+++ b/pkg/workers/linkresolver/link_resolving.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gardener/docforge/cmd/hugo"
 	"github.com/gardener/docforge/pkg/link"
 	"github.com/gardener/docforge/pkg/manifest"
-	"github.com/gardener/docforge/pkg/must"
 	"github.com/gardener/docforge/pkg/registry"
 	"github.com/gardener/docforge/pkg/registry/repositoryhost"
 	"k8s.io/klog/v2"
@@ -75,7 +74,7 @@ func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.N
 	if destinationResource.GetResourceSuffix() != "" {
 		return link.Build("/", l.Hugo.BaseURL, websiteLink, destinationResource.GetResourceSuffix())
 	}
-	return fmt.Sprintf("/%s", must.Succeed(link.Build(l.Hugo.BaseURL, websiteLink))), nil
+	return link.Build("/", l.Hugo.BaseURL, websiteLink)
 }
 
 func (l *LinkResolver) resolveDestinationNode(destinationResourceURL string, node *manifest.Node) (*manifest.Node, error) {

--- a/pkg/workers/linkresolver/link_resolving.go
+++ b/pkg/workers/linkresolver/link_resolving.go
@@ -7,7 +7,6 @@ package linkresolver
 import (
 	"cmp"
 	"fmt"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -74,7 +73,7 @@ func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.N
 		websiteLink = strings.TrimPrefix(websiteLink, structuralDir+"/")
 	}
 	if destinationResource.GetResourceSuffix() != "" {
-		return fmt.Sprintf("/%s/%s", path.Join(l.Hugo.BaseURL, websiteLink), destinationResource.GetResourceSuffix()), nil
+		return link.Build("/", l.Hugo.BaseURL, websiteLink, destinationResource.GetResourceSuffix())
 	}
 	return fmt.Sprintf("/%s", must.Succeed(link.Build(l.Hugo.BaseURL, websiteLink))), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace concatenation, `path.Join` and `fmt.Sprintf` with unified `link.Build` and `link.MustBuild`.

**Which issue(s) this PR fixes**:
Fixes #378

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
