### PR TITLE
Add e2e test to task

### DIFF
--- a/task.sh
+++ b/task.sh
@@ -36,6 +36,15 @@ echo "Running tests:"
 .ci/test > /dev/null 2>&1
 echo "Running integration tests:"
 .ci/integration-test > /dev/null 2>&1
+echo
+echo "Commiting task-changes-for-e2e on current branch."
+echo -e "\033[1;33mNote:\033[0m Revert commit using git reset --soft HEAD~1 if e2e fails"
+echo
+git commit -m"task-changes-for-e2e"
+echo "Running e2e tests:" 
+test/e2e/diff.sh  > /dev/null 2>&1
+echo "Reverting task-changes-for-e2e from current branch:"
+git reset --soft HEAD~1
 
 longest_common_prefix() {
     prefix=$1

--- a/test/e2e/diff.sh
+++ b/test/e2e/diff.sh
@@ -13,6 +13,22 @@ docforge_bin="${docforge_repo_path}/bin/docforge"
 
 echo Docforge repo: "$docforge_repo_path"
 
+cleanup() {
+  echo "Performing cleanup..."
+  rm -rf "${hugo}"
+  rm -rf "${PR_hugo}"
+  pushd "$docforge_repo_path"
+  if [[ -n "$current_branch" ]]; then
+      git checkout "$current_branch"
+  else
+      echo "current_branch is empty"
+  fi
+  mv "VERSION_PR" "VERSION"
+  popd
+}
+
+trap cleanup EXIT
+
 echo "Clean old build if done"
 rm -rf "$hugo"
 rm -rf "$PR_hugo"
@@ -40,13 +56,5 @@ echo "Diff results"
 rm -rf "${hugo}/content/__resources" 
 rm -rf "${PR_hugo}/content/__resources" 
 diff -r "$hugo" "$PR_hugo"
-rm -rf "${hugo}"
-rm -rf "${PR_hugo}"
 
-pushd "$docforge_repo_path"
-if [[ -n "$current_branch" ]]; then
-    git checkout "$current_branch"
-else
-    echo "current_branch is empty"
-fi
-mv "VERSION_PR" "VERSION"
+# Cleanup will be handled by the trap


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the execution of the e2e test when running `make task`

**Special notes for your reviewer**:
It can be tested by adding
```go
	if name == "logging.md" {
		return nil
	}
```
in `fswriter.Write` to force a failing e2e test

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
