### PR TITLE
Support fileTree for root repo directory

### DIFF
--- a/pkg/registry/repositoryhost/resource_url.go
+++ b/pkg/registry/repositoryhost/resource_url.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	rawPrefixed       = regexp.MustCompile(`https://(github.com|github.tools.sap|raw.github.tools.sap|github.wdf.sap.corp)/raw/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
-	resource          = regexp.MustCompile(`https://(github.com|github.tools.sap|raw.github.tools.sap|github.wdf.sap.corp)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
+	resource          = regexp.MustCompile(`https://(github.com|github.tools.sap|raw.github.tools.sap|github.wdf.sap.corp)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?([^\?#]*)(.*)`)
 	githubusercontent = regexp.MustCompile(`https://raw.githubusercontent.com/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
 )
 

--- a/pkg/registry/repositoryhost/resource_url_test.go
+++ b/pkg/registry/repositoryhost/resource_url_test.go
@@ -12,6 +12,18 @@ var _ = Describe("URL", func() {
 		err error
 	)
 
+	Describe("Root repo directory", func() {
+		BeforeEach(func() {
+			r, err = repositoryhost.NewResourceURL("https://github.com/owner/repo/tree/master")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should build resource.URL correctly", func() {
+			Expect(r.String()).To(Equal("https://github.com/owner/repo/tree/master"))
+		})
+
+	})
+
 	Describe("anchors with /", func() {
 		BeforeEach(func() {
 			r, err = repositoryhost.NewResourceURL("https://github.com/owner/repo/blob/master/docs/dev/local_setup.md#foo/bar")


### PR DESCRIPTION
**What this PR does / why we need it**:
As the regex requires a backslash between the ref and resourcePath this PR makes this backslash optional

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
