### PR TITLE
Improve assertion panic message

### DIFF
--- a/pkg/internal/must/assertions.go
+++ b/pkg/internal/must/assertions.go
@@ -1,6 +1,9 @@
 package must
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Package is inspired by https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md
 // "Assertions detect programmer errors. Unlike operating errors, which are expected and which must be handled, assertion failures are unexpected.
@@ -12,7 +15,7 @@ import "fmt"
 // Succeed panics on error.
 func Succeed[T any](obj T, err error) T {
 	if err != nil {
-		panic(fmt.Errorf("assertion failed: %w", err))
+		panic(fmt.Errorf("bug found through a failed assertion. Please create an issue containing the stack trace or open a PR fixing it: %w", err))
 	}
 	return obj
 }
@@ -20,13 +23,13 @@ func Succeed[T any](obj T, err error) T {
 // BeTrue panics if value is false
 func BeTrue(value bool) {
 	if !value {
-		panic(fmt.Sprintf("assertion failed: expected %t to be true", value))
+		panic(errors.New("bug found through a failed assertion. Please create an issue containing the stack trace or open a PR fixing it"))
 	}
 }
 
 // BeFalse panics if value is true
 func BeFalse(value bool) {
 	if value {
-		panic(fmt.Sprintf("assertion failed: expected %t to be false", value))
+		panic(errors.New("bug found through a failed assertion. Please create an issue containing the stack trace or open a PR fixing it"))
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves assertion panic message to guide the reader how to handle the error. Broken assertions are programmer errors and therefore bugs to be fixed instead of a misuse of the tool (for example providing broken manifest URL which are not bugs but user errors)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
