### PR TITLE
Improve `filetypefilter` plugin

### DIFF
--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -75,8 +75,10 @@ func exec(ctx context.Context, vip *viper.Viper) error {
 		pluginTransformations = append(pluginTransformations, markdownPlugin.PluginNodeTransformations()...)
 	}
 
-	fileTypeFilterPlugin := filetypefilter.FileTypeFilter{ContentFileFormats: options.Options.ContentFileFormats}
-	pluginTransformations = append(pluginTransformations, fileTypeFilterPlugin.PluginNodeTransformations()...)
+	if len(options.Options.ContentFileFormats) > 0 {
+		fileTypeFilterPlugin := filetypefilter.FileTypeFilter{ContentFileFormats: options.Options.ContentFileFormats}
+		pluginTransformations = append(pluginTransformations, fileTypeFilterPlugin.PluginNodeTransformations()...)
+	}
 
 	documentNodes, err := manifest.ResolveManifest(manifestURL, rhRegistry, pluginTransformations...)
 	if err != nil {

--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+// TODO remove the ignore
+//
 //gocyclo:ignore
 func exec(ctx context.Context, vip *viper.Viper) error {
 	var (

--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+//gocyclo:ignore
 func exec(ctx context.Context, vip *viper.Viper) error {
 	var (
 		rhs     []repositoryhost.Interface

--- a/cmd/app/flags.go
+++ b/cmd/app/flags.go
@@ -73,7 +73,7 @@ func configureFlags(command *cobra.Command, vip *viper.Viper) {
 		"When building a Hugo-compliant documentation bundle, files with filename matching one form this list (in that order) will be renamed to _index.md. Only useful with --hugo=true")
 	_ = vip.BindPFlag("hugo-section-files", command.Flags().Lookup("hugo-section-files"))
 
-	command.Flags().StringSlice("content-files-formats", []string{".md"},
+	command.Flags().StringSlice("content-files-formats", []string{},
 		"Supported content format extensions (example: .md)")
 	_ = vip.BindPFlag("content-files-formats", command.Flags().Lookup("content-files-formats"))
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -91,6 +91,9 @@ func processTransformation(f NodeTransformation, node *Node, parent *Node, r reg
 	if err != nil {
 		return runTreeChangeProcedure, err
 	}
+	if node == nil {
+		return false, nil
+	}
 
 	for _, nodeChild := range node.Structure {
 		childRunTreeChangeProcedure, err := processTransformation(f, nodeChild, node, r)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -91,12 +91,9 @@ func processTransformation(f NodeTransformation, node *Node, parent *Node, r reg
 	if err != nil {
 		return runTreeChangeProcedure, err
 	}
-	if node == nil {
-		return false, nil
-	}
-
-	for _, nodeChild := range node.Structure {
-		childRunTreeChangeProcedure, err := processTransformation(f, nodeChild, node, r)
+	// using this kind of looping as f may change node.Structure
+	for i := 0; i < len(node.Structure); i++ {
+		childRunTreeChangeProcedure, err := processTransformation(f, node.Structure[i], node, r)
 		if err != nil {
 			if node.Manifest != "" {
 				return runTreeChangeProcedure, fmt.Errorf("manifest %s -> %w", node.Manifest, err)

--- a/pkg/manifestplugins/filetypefilter/plugin.go
+++ b/pkg/manifestplugins/filetypefilter/plugin.go
@@ -25,8 +25,10 @@ func (d *FileTypeFilter) checkFileTypeFormats(node *manifest.Node, parent *manif
 	}
 
 	changed := false
-	for _, file := range node.FileType.MultiSource {
-		if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool { return strings.HasSuffix(file, fileFormat) || file == "" }) && parent != nil {
+	checkAndUpdateNode := func(file string) {
+		if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool {
+			return strings.HasSuffix(file, fileFormat) || file == ""
+		}) && parent != nil {
 			if idx := slices.Index(parent.Structure, node); idx != -1 {
 				parent.Structure[idx] = nil
 				changed = true
@@ -34,23 +36,11 @@ func (d *FileTypeFilter) checkFileTypeFormats(node *manifest.Node, parent *manif
 		}
 	}
 
-	if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool {
-		return strings.HasSuffix(node.FileType.Source, fileFormat) || node.FileType.Source == ""
-	}) && parent != nil {
-		if idx := slices.Index(parent.Structure, node); idx != -1 {
-			parent.Structure[idx] = nil
-			changed = true
-		}
+	for _, file := range node.FileType.MultiSource {
+		checkAndUpdateNode(file)
 	}
-
-	if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool {
-		return strings.HasSuffix(node.FileType.File, fileFormat) || node.FileType.File == ""
-	}) && parent != nil {
-		if idx := slices.Index(parent.Structure, node); idx != -1 {
-			parent.Structure[idx] = nil
-			changed = true
-		}
-	}
+	checkAndUpdateNode(node.FileType.Source)
+	checkAndUpdateNode(node.FileType.File)
 
 	if parent != nil {
 		parent.Structure = slices.DeleteFunc(parent.Structure, func(ptr *manifest.Node) bool {

--- a/pkg/manifestplugins/filetypefilter/plugin.go
+++ b/pkg/manifestplugins/filetypefilter/plugin.go
@@ -19,15 +19,45 @@ func (d *FileTypeFilter) PluginNodeTransformations() []manifest.NodeTransformati
 	return []manifest.NodeTransformation{d.checkFileTypeFormats}
 }
 
-func (d *FileTypeFilter) checkFileTypeFormats(node *manifest.Node, _ *manifest.Node, r registry.Interface) (bool, error) {
-	if node.Type != "file" {
+func (d *FileTypeFilter) checkFileTypeFormats(node *manifest.Node, parent *manifest.Node, r registry.Interface) (bool, error) {
+	if node == nil || node.Type != "file" {
 		return false, nil
 	}
-	files := append(node.FileType.MultiSource, node.FileType.Source, node.FileType.File)
-	for _, file := range files {
-		// we do || file == "" to skip empty fields
-		if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool { return strings.HasSuffix(file, fileFormat) || file == "" }) {
-			return false, fmt.Errorf("file format of %s isn't supported", file)
+
+	changed := false
+	for _, file := range node.FileType.MultiSource {
+		if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool { return strings.HasSuffix(file, fileFormat) || file == "" }) && parent != nil {
+			if idx := slices.Index(parent.Structure, node); idx != -1 {
+				parent.Structure[idx] = nil
+				changed = true
+			}
+		}
+	}
+
+	if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool {
+		return strings.HasSuffix(node.FileType.Source, fileFormat) || node.FileType.Source == ""
+	}) && parent != nil {
+		if idx := slices.Index(parent.Structure, node); idx != -1 {
+			parent.Structure[idx] = nil
+			changed = true
+		}
+	}
+
+	if !slices.ContainsFunc(d.ContentFileFormats, func(fileFormat string) bool {
+		return strings.HasSuffix(node.FileType.File, fileFormat) || node.FileType.File == ""
+	}) && parent != nil {
+		if idx := slices.Index(parent.Structure, node); idx != -1 {
+			parent.Structure[idx] = nil
+			changed = true
+		}
+	}
+
+	if parent != nil {
+		parent.Structure = slices.DeleteFunc(parent.Structure, func(ptr *manifest.Node) bool {
+			return ptr == nil
+		})
+		if changed && len(parent.Structure) == 0 {
+			return false, fmt.Errorf("node\n %v\n has no files with supported formats: %v", parent.String(), d.ContentFileFormats)
 		}
 	}
 	return false, nil

--- a/pkg/manifestplugins/filetypefilter/tests/manifests/filtered_file_format.yaml
+++ b/pkg/manifestplugins/filetypefilter/tests/manifests/filtered_file_format.yaml
@@ -1,0 +1,5 @@
+structure:
+- dir: invalid
+  structure:
+  - file: /contents/blogs/2024/invalid.file
+  - file: /contents/blogs/2024/valid.yaml

--- a/pkg/manifestplugins/filetypefilter/tests/results/filtered_file_format.yaml
+++ b/pkg/manifestplugins/filetypefilter/tests/results/filtered_file_format.yaml
@@ -1,0 +1,5 @@
+- file: valid.yaml
+  processor: downloader
+  type: file
+  source: https://github.com/gardener/docforge/blob/master/contents/blogs/2024/valid.yaml
+  path: invalid

--- a/test/e2e/docforge_config.yaml
+++ b/test/e2e/docforge_config.yaml
@@ -16,17 +16,8 @@ content-files-formats:
 - ".svg"
 - ".jpg"
 - ".jpeg" 
-- ".sketch" #remove everything from this row down, when cleanup of repos is done
 - ".gif"
-- ".afphoto"
-- ".pptx"
-- ".yaml"
-- ".dot"
-- ".mmd"
 - ".txt"
-- ".drawio"
-- ".ico"
-- ".ttf"
 - ".woff"
 - ".woff2"
 resources-download-path: content/__resources

--- a/test/e2e/docforge_config.yaml
+++ b/test/e2e/docforge_config.yaml
@@ -17,9 +17,6 @@ content-files-formats:
 - ".jpg"
 - ".jpeg" 
 - ".gif"
-- ".txt"
-- ".woff"
-- ".woff2"
 resources-download-path: content/__resources
 github-oauth-env-map:
   "github.com": GITHUB_OAUTH_TOKEN


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves `filetypefilter` plugin in order not to error when met with an unsupported type and just ignore it. It will only error if a whole dir gets emptied by the filtering.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
cc @Kostov6 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
`filetypefilter` plugin will filter out files that aren't specified in the content formats field. It will only error if a whole dir gets emptied by the filtering.
```
