### PR TITLE
Add `Markdown` processor check to `Docsy` plugin

### DIFF
--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -61,10 +61,6 @@ func exec(ctx context.Context, vip *viper.Viper) error {
 	rhRegistry := registry.NewRegistry(append(localRH, config.RepositoryHosts...)...)
 
 	pluginTransformations := []manifest.NodeTransformation{}
-	if options.Docsy.EditThisPageEnabled {
-		docsyPlugin := docsy.Docsy{}
-		pluginTransformations = append(pluginTransformations, docsyPlugin.PluginNodeTransformations()...)
-	}
 	if options.Persona.PersonaFilterEnabled {
 		personaPlugin := persona.Persona{}
 		pluginTransformations = append(pluginTransformations, personaPlugin.PluginNodeTransformations()...)
@@ -76,6 +72,10 @@ func exec(ctx context.Context, vip *viper.Viper) error {
 	if options.Markdown.MarkdownEnabled {
 		markdownPlugin := manifestmarkdown.Markdown{}
 		pluginTransformations = append(pluginTransformations, markdownPlugin.PluginNodeTransformations()...)
+	}
+	if options.Docsy.EditThisPageEnabled {
+		docsyPlugin := docsy.Docsy{}
+		pluginTransformations = append(pluginTransformations, docsyPlugin.PluginNodeTransformations()...)
 	}
 
 	if len(options.Options.ContentFileFormats) > 0 {

--- a/pkg/manifestplugins/docsy/plugin.go
+++ b/pkg/manifestplugins/docsy/plugin.go
@@ -20,7 +20,8 @@ func (d *Docsy) PluginNodeTransformations() []manifest.NodeTransformation {
 func editThisPage(node *manifest.Node, _ *manifest.Node, r registry.Interface) (bool, error) {
 	if node.Type != "file" ||
 		(node.File == "_index.md" && node.Source == "") ||
-		(len(node.MultiSource) > 0) {
+		(len(node.MultiSource) > 0) ||
+		node.Processor != "markdown" {
 		return false, nil
 	}
 	url, err := r.ResourceURL(node.Source)

--- a/pkg/manifestplugins/docsy/plugin_test.go
+++ b/pkg/manifestplugins/docsy/plugin_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gardener/docforge/pkg/manifest"
 	"github.com/gardener/docforge/pkg/manifestplugins/docsy"
+	"github.com/gardener/docforge/pkg/manifestplugins/markdown"
 	"github.com/gardener/docforge/pkg/registry"
 	"github.com/gardener/docforge/pkg/registry/repositoryhost"
 	. "github.com/onsi/ginkgo"
@@ -45,8 +46,10 @@ var _ = Describe("Docsy test", func() {
 			r := registry.NewRegistry(repositoryhost.NewLocalTest(repo, "https://github.com/gardener/docforge", "tests"))
 
 			url := "https://github.com/gardener/docforge/blob/master/" + exampleFile
+			markdownPlugin := markdown.Markdown{}
+			additionalTransformations := markdownPlugin.PluginNodeTransformations()
 			docsyPlugin := docsy.Docsy{}
-			additionalTransformations := docsyPlugin.PluginNodeTransformations()
+			additionalTransformations = append(additionalTransformations, docsyPlugin.PluginNodeTransformations()...)
 			allNodes, err := manifest.ResolveManifest(url, r, additionalTransformations...)
 			Expect(err).ToNot(HaveOccurred())
 			files := []*manifest.Node{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Docsy plugin transformation needs to be executed after the Markdown plugin ones.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
cc @Kostov6 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
