### PR TITLE
Add `TODO: implement empty dir logic after manifests have been cleaned up from empty dirs`

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -97,9 +97,12 @@ func removeNilNodes(node *Node) error {
 	node.Structure = slices.DeleteFunc(node.Structure, func(child *Node) bool {
 		return child == nil
 	})
-	if node.Type == "dir" && len(node.Structure) == 0 {
-		return fmt.Errorf("there is an empty directory with path %s", node.NodePath())
-	}
+
+	// TODO: implement this logic after manifests have been cleaned up from empty dirs
+	// if node.Type == "dir" && len(node.Structure) == 0 {
+	// 	return fmt.Errorf("there is an empty directory with path %s", node.NodePath())
+	// }
+
 	for _, child := range node.Structure {
 		if err := removeNilNodes(child); err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
TODO: implement this logic after manifests have been cleaned up from empty dirs

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
