### PR TITLE
Enable import of a whole repository in manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,5 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )

--- a/go.sum
+++ b/go.sum
@@ -437,4 +437,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=
 k8s.io/klog/v2 v2.120.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
+k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/registry/repositoryhost/github_http_cache_test.go
+++ b/pkg/registry/repositoryhost/github_http_cache_test.go
@@ -93,6 +93,11 @@ var _ = Describe("Github cache test", func() {
 				Type: github.String("blob"),
 				SHA:  github.String("10"),
 			},
+			{
+				Path: github.String(""),
+				Type: github.String("tree"),
+				SHA:  github.String("0"),
+			},
 		},
 	}
 	git.GetTreeReturns(&tree, nil, nil)

--- a/pkg/registry/repositoryhost/repository_host_test.go
+++ b/pkg/registry/repositoryhost/repository_host_test.go
@@ -23,12 +23,11 @@ func testRepositoryHost(ghc repositoryhost.Interface) {
 		})
 
 		It("should list all files", func() {
-			resourceURl, err := ghc.ResourceURL("https://github.com/gardener/docforge/tree/master/pkg")
+			resourceURl, err := ghc.ResourceURL("https://github.com/gardener/docforge/tree/master")
 			Expect(err).NotTo(HaveOccurred())
 			tree, err := ghc.Tree(*resourceURl)
-			Expect(tree).To(ContainElements([]string{"main.go", "api/type.go"}))
+			Expect(tree).To(ContainElements([]string{"pkg/main.go", "pkg/api/type.go"}))
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 		It("should list the proper files", func() {
 			resourceURl, err := ghc.ResourceURL("https://github.com/gardener/docforge/tree/master/docs")


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables the use of a repository as a whole by using
``` 
fileTree: <link to repository>/tree/<branch>
```
Example: https://github.com/gardener/documentation/tree/master in order to use the master branch

**Which issue(s) this PR fixes**:
Fixes #429 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Manifests now support imports of repositories using fileTree.
```
