### PR TITLE
refactor: add `index.md` as node.file and simplify conditions in edit…

### DIFF
--- a/pkg/manifestplugins/docsy/plugin.go
+++ b/pkg/manifestplugins/docsy/plugin.go
@@ -18,10 +18,14 @@ func (d *Docsy) PluginNodeTransformations() []manifest.NodeTransformation {
 }
 
 func editThisPage(node *manifest.Node, _ *manifest.Node, r registry.Interface) (bool, error) {
-	if node.Type != "file" ||
-		(node.File == "_index.md" && node.Source == "") ||
-		(len(node.MultiSource) > 0) ||
-		node.Processor != "markdown" {
+	isNotFile := node.Type != "file"
+	isIndexFileWithoutSource := (node.File == "_index.md" || node.File == "index.md") && node.Source == ""
+	hasMultipleSource := len(node.MultiSource) > 0
+	isNotMarkdown := node.Processor != "markdown"
+
+	shouldSkipNode := isNotFile || isIndexFileWithoutSource || hasMultipleSource || isNotMarkdown
+
+	if shouldSkipNode {
 		return false, nil
 	}
 	url, err := r.ResourceURL(node.Source)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapts the editThisPageFunction to also skip `index.md` files as well. 
This enabled us to partially drop support for _index.md files und reduces the post-processing burden in https://github.com/gardener/documentation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
