### PR TITLE
Fix broken proposal anchor links and GitHub Actions badge URLs

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -325,10 +325,6 @@ func constructNodeTree(files []string, node *Node, parent *Node) (bool, error) {
 			return changed, err
 		}
 		fileName := path.Base(file)
-		// Rename README.md files to index.md
-		if strings.EqualFold(fileName, "README.md") {
-			fileName = "index.md"
-		}
 		filePath, err := link.Build(node.Path, path.Dir(file))
 		if err != nil {
 			return changed, err

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -325,6 +325,10 @@ func constructNodeTree(files []string, node *Node, parent *Node) (bool, error) {
 			return changed, err
 		}
 		fileName := path.Base(file)
+		// Rename README.md files to index.md
+		if strings.EqualFold(fileName, "README.md") {
+			fileName = "index.md"
+		}
 		filePath, err := link.Build(node.Path, path.Dir(file))
 		if err != nil {
 			return changed, err

--- a/pkg/manifest/node.go
+++ b/pkg/manifest/node.go
@@ -67,6 +67,8 @@ func (n *Node) HugoPrettyPath() string {
 	}
 	name = strings.TrimSuffix(name, ".md")
 	name = strings.TrimSuffix(name, "_index")
+	// TODO: use IndexFileNames instead
+	name = strings.TrimSuffix(name, "README")
 	return must.Succeed(link.Build(n.Path, name, "/"))
 }
 

--- a/pkg/nodeplugins/markdown/linkresolver/link_resolving.go
+++ b/pkg/nodeplugins/markdown/linkresolver/link_resolving.go
@@ -58,6 +58,10 @@ func New(structure []*manifest.Node, rhs registry.Interface, hugo hugo.Hugo) *Li
 
 // ResolveResourceLink resolves resource link from a given source
 func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.Node, source string) (string, error) {
+	// fragment-only links (e.g. #heading) are same-document anchors — pass through unchanged
+	if strings.HasPrefix(resourceLink, "#") {
+		return resourceLink, nil
+	}
 	// handle relative links to resources
 	if repositoryhost.IsRelative(resourceLink) {
 		var err error

--- a/pkg/registry/repositoryhost/resource_url.go
+++ b/pkg/registry/repositoryhost/resource_url.go
@@ -31,11 +31,14 @@ func IsRelative(link string) bool {
 	return !url.IsAbs()
 }
 
-// RawURL returns the GitHub raw URL if the resource is 'blob', otherwise returns the origin URL
+// RawURL returns the GitHub raw URL for the resource, unless the resource type is 'actions' in which case it returns the origin URL
 func RawURL(resourceURL string) (string, error) {
 	r, err := new(resourceURL)
 	if err != nil {
 		return "", err
+	}
+	if r.resourceType == "actions" {
+		return resourceURL, nil
 	}
 	return link.Build("https://", r.host, r.owner, r.repo, "raw", r.ref, r.resourcePath)
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**Why do we need the PR**:
1. The table-of-contents links in the [Proposals](https://gardener.cloud/docs/proposals/) section of the public Gardener website are broken. The anchor links are converted to full paths, but the `readme` suffix is not stripped during the process, resulting in links such as `https://gardener.cloud/docs/proposals/0001-gardener-extensibility/readme/#infrastructure-provisioning`.

2. GitHub Actions badge URLs were being mangled. Badge image URLs like                                   `https://github.com/owner/repo/actions/workflows/build.yaml/badge.svg` were rewritten to `https://github.com/owner/repo/raw/workflows/build.yaml/badge.svg`, causing badges to not render. 

**What does the PR do**:
~~Updates `manifest.go` so that `README.md` files in the file tree are renamed to `index.md`.~~

- Updated `HugoPrettyPath()` in `pkg/manifest/node.go` to strip the `README` suffix, mirroring the existing handling of `_index`.
- Updated `RawURL()` in `pkg/registry/repositoryhost/resource_url.go` to skip the raw conversion for actions resource types, returning the original URL unchanged.  

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/documentation/issues/857
Fixes https://github.com/gardener/documentation/issues/835

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
