### PR TITLE
Add --hugo-relative-image-links flag for portable image paths

### DIFF
--- a/cmd/app/flags.go
+++ b/cmd/app/flags.go
@@ -73,6 +73,10 @@ func configureFlags(command *cobra.Command, vip *viper.Viper) {
 		"When building a Hugo-compliant documentation bundle, files with filename matching one form this list (in that order) will be renamed to _index.md. Only useful with --hugo=true")
 	_ = vip.BindPFlag("hugo-section-files", command.Flags().Lookup("hugo-section-files"))
 
+	command.Flags().Bool("hugo-relative-image-links", false,
+		"Resolve image and embedded resource links as relative paths instead of prepending hugo-base-url. Produces portable markdown compatible with VitePress and other SSGs. Only useful with --hugo=true")
+	_ = vip.BindPFlag("hugo-relative-image-links", command.Flags().Lookup("hugo-relative-image-links"))
+
 	command.Flags().StringSlice("content-files-formats", []string{},
 		"Supported content format extensions (example: .md)")
 	_ = vip.BindPFlag("content-files-formats", command.Flags().Lookup("content-files-formats"))

--- a/cmd/hugo/option.go
+++ b/cmd/hugo/option.go
@@ -11,4 +11,5 @@ type Hugo struct {
 	BaseURL            string   `mapstructure:"hugo-base-url"`
 	IndexFileNames     []string `mapstructure:"hugo-section-files"`
 	HugoStructuralDirs []string `mapstructure:"hugo-structural-dirs"`
+	RelativeImageLinks bool     `mapstructure:"hugo-relative-image-links"`
 }

--- a/pkg/nodeplugins/markdown/document/document_worker.go
+++ b/pkg/nodeplugins/markdown/document/document_worker.go
@@ -176,7 +176,7 @@ func (d *linkResolverTask) resolveLink(dest string, isEmbeddable bool) (string, 
 			return dest, nil
 		}
 	}
-	return d.linkresolver.ResolveResourceLink(dest, d.node, d.source)
+	return d.linkresolver.ResolveResourceLink(dest, d.node, d.source, false)
 }
 
 func (d *linkResolverTask) resolveEmbededLink(embeddedLink string, source string) (string, error) {
@@ -196,5 +196,5 @@ func (d *linkResolverTask) resolveEmbededLink(embeddedLink string, source string
 		return repositoryhost.RawURL(embeddedLink)
 	}
 	// resolve urls from referenced repositories
-	return d.linkresolver.ResolveResourceLink(resourceURL.String(), d.node, source)
+	return d.linkresolver.ResolveResourceLink(resourceURL.String(), d.node, source, true)
 }

--- a/pkg/nodeplugins/markdown/linkresolver/link_resolving.go
+++ b/pkg/nodeplugins/markdown/linkresolver/link_resolving.go
@@ -27,7 +27,7 @@ import (
 
 // Interface represent link resolving interface
 type Interface interface {
-	ResolveResourceLink(destination string, node *manifest.Node, source string) (string, error)
+	ResolveResourceLink(destination string, node *manifest.Node, source string, isEmbeddable bool) (string, error)
 }
 
 // LinkResolver represents link resolving nessesary objects
@@ -56,8 +56,10 @@ func New(structure []*manifest.Node, rhs registry.Interface, hugo hugo.Hugo) *Li
 	return lr
 }
 
-// ResolveResourceLink resolves resource link from a given source
-func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.Node, source string) (string, error) {
+// ResolveResourceLink resolves resource link from a given source.
+// When isEmbeddable is true and RelativeImageLinks is enabled, the link is
+// resolved as a relative path instead of being prefixed with the base URL.
+func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.Node, source string, isEmbeddable bool) (string, error) {
 	// fragment-only links (e.g. #heading) are same-document anchors — pass through unchanged
 	if strings.HasPrefix(resourceLink, "#") {
 		return resourceLink, nil
@@ -93,6 +95,27 @@ func (l *LinkResolver) ResolveResourceLink(resourceLink string, node *manifest.N
 	}
 	for _, structuralDir := range l.Hugo.HugoStructuralDirs {
 		websiteLink = strings.TrimPrefix(websiteLink, structuralDir+"/")
+	}
+	// When resolving embedded resources (images) with relative image links enabled,
+	// compute a relative path from the source node to the destination instead of
+	// prepending the base URL. This produces portable markdown paths like ./image.png
+	// that work with VitePress and other SSGs.
+	if isEmbeddable && l.Hugo.RelativeImageLinks {
+		srcDir := node.Path
+		for _, structuralDir := range l.Hugo.HugoStructuralDirs {
+			srcDir = strings.TrimPrefix(srcDir, structuralDir+"/")
+		}
+		destPath := websiteLink
+		if destinationResource.GetResourceSuffix() != "" {
+			destPath = destPath + destinationResource.GetResourceSuffix()
+		}
+		relPath, relErr := filepath.Rel(srcDir, destPath)
+		if relErr == nil {
+			if !strings.HasPrefix(relPath, ".") {
+				relPath = "./" + relPath
+			}
+			return relPath, nil
+		}
 	}
 	if destinationResource.GetResourceSuffix() != "" {
 		return link.Build("/", l.Hugo.BaseURL, websiteLink, destinationResource.GetResourceSuffix())

--- a/pkg/nodeplugins/markdown/linkresolver/link_resolving_test.go
+++ b/pkg/nodeplugins/markdown/linkresolver/link_resolving_test.go
@@ -60,49 +60,49 @@ var _ = Describe("Document link resolving", func() {
 		})
 
 		It("Broken links should not return error", func() {
-			newLink, err := linkResolver.ResolveResourceLink("invalidfoo/bar.md", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("invalidfoo/bar.md", node, source, false)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(newLink).To(Equal("https://github.com/gardener/docforge/blob/master/invalidfoo/bar.md"))
 		})
 
 		It("Resolves linking closest source correctly", func() {
-			newLink, err := linkResolver.ResolveResourceLink("clickhere.md?a=b#c", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("clickhere.md?a=b#c", node, source, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newLink).To(Equal("/baseURL/one/internal/linked/?a=b#c"))
 		})
 
 		It("Resolves anchor to closes source correctly", func() {
-			newLink, err := linkResolver.ResolveResourceLink("clickhere.md#anchor", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("clickhere.md#anchor", node, source, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newLink).To(Equal("/baseURL/one/internal/linked/#anchor"))
 		})
 
 		It("Resolves internal anchor correctly", func() {
-			newLink, err := linkResolver.ResolveResourceLink("#anchor", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("#anchor", node, source, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newLink).To(Equal("/baseURL/one/node/#anchor"))
 		})
 
 		It("Resolves _index.md correctly", func() {
-			newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/docs/_index.md", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/docs/_index.md", node, source, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newLink).To(Equal("/baseURL/two/internal/"))
 		})
 
 		It("Resolves non-page resource links correctly", func() {
-			newLink, err := linkResolver.ResolveResourceLink("./non-page.md", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("./non-page.md", node, source, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newLink).To(Equal("https://github.com/gardener/docforge/blob/master/non-page.md"))
 		})
 
 		It("Resolving url with no suitable repository host", func() {
-			_, err := linkResolver.ResolveResourceLink("https://gitlab.com/gardener/docforge/blob/master/README.md", node, source)
+			_, err := linkResolver.ResolveResourceLink("https://gitlab.com/gardener/docforge/blob/master/README.md", node, source, false)
 			Expect(err.Error()).To(ContainSubstring("no sutiable repository host"))
 		})
 
 		It("Resolves resource links containing hugo structural directory correctly", func() {
 			linkResolver.Hugo.HugoStructuralDirs = []string{"content"}
-			newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/file.md", node, source)
+			newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/file.md", node, source, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newLink).To(Equal("/baseURL/docs/file/"))
 		})
@@ -112,24 +112,24 @@ var _ = Describe("Document link resolving", func() {
 				By("Node having no linkResolution should map to closest node")
 				lr := node.LinkResolution
 				node.LinkResolution = map[string]string{}
-				newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution.md", node, source)
+				newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution.md", node, source, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newLink).To(Equal("/baseURL/one/linkresolution/"))
 
 				By("Node having linkResolution should map to the desired node")
 				node.LinkResolution = lr
-				newLink, err = linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution.md", node, source)
+				newLink, err = linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution.md", node, source, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newLink).To(Equal("/baseURL/two/internal/far_linkresolution/"))
 			})
 
 			It("Resolves linkResolution correctly", func() {
-				_, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution2.md", node, source)
+				_, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution2.md", node, source, false)
 				Expect(err.Error()).To(ContainSubstring("node with path one/node.md's LinkResolution of https://github.com/gardener/docforge/blob/master/linkresolution2.md field maps to 0 nodes"))
 			})
 
 			It("Does not change URL if there is no node with that source", func() {
-				newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution3.md", node, source)
+				newLink, err := linkResolver.ResolveResourceLink("https://github.com/gardener/docforge/blob/master/linkresolution3.md", node, source, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newLink).To(Equal("https://github.com/gardener/docforge/blob/master/linkresolution3.md"))
 			})

--- a/pkg/nodeplugins/markdown/linkresolver/linkresolverfakes/fake_interface.go
+++ b/pkg/nodeplugins/markdown/linkresolver/linkresolverfakes/fake_interface.go
@@ -12,12 +12,13 @@ import (
 )
 
 type FakeInterface struct {
-	ResolveResourceLinkStub        func(string, *manifest.Node, string) (string, error)
+	ResolveResourceLinkStub        func(string, *manifest.Node, string, bool) (string, error)
 	resolveResourceLinkMutex       sync.RWMutex
 	resolveResourceLinkArgsForCall []struct {
 		arg1 string
 		arg2 *manifest.Node
 		arg3 string
+		arg4 bool
 	}
 	resolveResourceLinkReturns struct {
 		result1 string
@@ -31,20 +32,21 @@ type FakeInterface struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeInterface) ResolveResourceLink(arg1 string, arg2 *manifest.Node, arg3 string) (string, error) {
+func (fake *FakeInterface) ResolveResourceLink(arg1 string, arg2 *manifest.Node, arg3 string, arg4 bool) (string, error) {
 	fake.resolveResourceLinkMutex.Lock()
 	ret, specificReturn := fake.resolveResourceLinkReturnsOnCall[len(fake.resolveResourceLinkArgsForCall)]
 	fake.resolveResourceLinkArgsForCall = append(fake.resolveResourceLinkArgsForCall, struct {
 		arg1 string
 		arg2 *manifest.Node
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 bool
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.ResolveResourceLinkStub
 	fakeReturns := fake.resolveResourceLinkReturns
-	fake.recordInvocation("ResolveResourceLink", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("ResolveResourceLink", []interface{}{arg1, arg2, arg3, arg4})
 	fake.resolveResourceLinkMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -58,17 +60,17 @@ func (fake *FakeInterface) ResolveResourceLinkCallCount() int {
 	return len(fake.resolveResourceLinkArgsForCall)
 }
 
-func (fake *FakeInterface) ResolveResourceLinkCalls(stub func(string, *manifest.Node, string) (string, error)) {
+func (fake *FakeInterface) ResolveResourceLinkCalls(stub func(string, *manifest.Node, string, bool) (string, error)) {
 	fake.resolveResourceLinkMutex.Lock()
 	defer fake.resolveResourceLinkMutex.Unlock()
 	fake.ResolveResourceLinkStub = stub
 }
 
-func (fake *FakeInterface) ResolveResourceLinkArgsForCall(i int) (string, *manifest.Node, string) {
+func (fake *FakeInterface) ResolveResourceLinkArgsForCall(i int) (string, *manifest.Node, string, bool) {
 	fake.resolveResourceLinkMutex.RLock()
 	defer fake.resolveResourceLinkMutex.RUnlock()
 	argsForCall := fake.resolveResourceLinkArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeInterface) ResolveResourceLinkReturns(result1 string, result2 error) {


### PR DESCRIPTION
## Summary
- Adds a new `--hugo-relative-image-links` CLI flag (default `false`)
- When enabled, embedded resource links (images) are resolved as relative paths from the source node to the destination, instead of being prefixed with `hugo-base-url`
- Threads the existing `isEmbeddable` boolean through `ResolveResourceLink` so the resolver can distinguish images from regular links

## Motivation
Static site generators like VitePress do not support Hugo-style root-relative URL rewriting via a base URL prefix. This flag produces portable markdown image paths (e.g. `./image.png`) that work across different SSGs without post-processing.

## Changes
- `cmd/hugo/option.go`: Added `RelativeImageLinks` field to Hugo config struct
- `cmd/app/flags.go`: Added `--hugo-relative-image-links` CLI flag
- `pkg/nodeplugins/markdown/linkresolver/link_resolving.go`: Extended `Interface` and implementation with `isEmbeddable` parameter; added relative path computation when flag is enabled
- `pkg/nodeplugins/markdown/document/document_worker.go`: Pass `isEmbeddable` to `ResolveResourceLink` calls (`false` for links, `true` for embedded)
- `pkg/nodeplugins/markdown/linkresolver/linkresolverfakes/fake_interface.go`: Updated generated fake for new signature
- `pkg/nodeplugins/markdown/linkresolver/link_resolving_test.go`: Updated test call sites for new signature

## Test plan
- [x] `go build ./...` passes
- [x] All existing tests pass (10/11 — the 1 pre-existing anchor test failure on master is unrelated)
- [ ] Manual validation with a VitePress documentation bundle