### PR TITLE
test(linkresolver): Resolve internal anchors to only contain anchor part

### DIFF
--- a/pkg/nodeplugins/markdown/linkresolver/link_resolving_test.go
+++ b/pkg/nodeplugins/markdown/linkresolver/link_resolving_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Document link resolving", func() {
 		It("Resolves internal anchor correctly", func() {
 			newLink, err := linkResolver.ResolveResourceLink("#anchor", node, source)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(newLink).To(Equal("/baseURL/one/node/#anchor"))
+			Expect(newLink).To(Equal("#anchor"))
 		})
 
 		It("Resolves _index.md correctly", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Test not adapted for https://github.com/gardener/docforge/pull/447

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
