### PR TITLE
fix: quote architecture in OCM extraIdentity to prevent int coercion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
             type: executable
             extraIdentity:
               os: ${{ matrix.args.os }}
-              architecture: ${{ matrix.args.arch }}
+              architecture: '${{ matrix.args.arch }}'
             access:
               type: localBlob
               localReference: docforge.tar.gz


### PR DESCRIPTION
## Summary

- GHA expands `${{ matrix.args.arch }}` into the inline YAML block without quotes, so `386` is parsed as a YAML integer rather than a string
- `extraIdentity` values must be strings per the OCM spec (`dict[str, str]`), causing `dacite.WrongTypeError` when the component descriptor is deserialised downstream (e.g. in the release-notes action)
- Fix: wrap the expression in single quotes so YAML treats it as a string literal

## Test plan

- [ ] Trigger a build for the windows/386 target and verify the release pipeline completes without `WrongTypeError`