### PR TITLE
feat: make GitHub host configurable via github-oauth-env-map

### DIFF
--- a/cmd/app/initilization.go
+++ b/cmd/app/initilization.go
@@ -42,6 +42,7 @@ func initRepositoryHosts(ctx context.Context, o repositoryhost.InitOptions) ([]r
 			errs = multierror.Append(errs, fmt.Errorf("couldn't parse url: %s", instance))
 			continue
 		}
+		repositoryhost.RegisterHost(u.Host)
 		cachePath := filepath.Join(o.CacheHomeDir, "diskv", host)
 		client, httpClient, err := buildClient(ctx, oAuthToken, instance, cachePath)
 		if err != nil {

--- a/pkg/registry/repositoryhost/export_test.go
+++ b/pkg/registry/repositoryhost/export_test.go
@@ -1,3 +1,9 @@
 package repositoryhost
 
 var NewResourceURL = new
+
+// ResetHosts restores knownHosts to its default state between tests.
+func ResetHosts() {
+	knownHosts = []string{"github.com"}
+	cachedRaw, cachedResource = buildRegexps()
+}

--- a/pkg/registry/repositoryhost/resource_url.go
+++ b/pkg/registry/repositoryhost/resource_url.go
@@ -15,10 +15,10 @@ var (
 	// knownHosts holds all GitHub-compatible hosts that docforge can process.
 	// Populated at startup via RegisterHost() for each entry in github-oauth-env-map.
 	// TODO: extend this mechanism to support GitLab hosts when a GitLab implementation is added.
-	knownHosts = []string{"github.com"}
+	knownHosts = []string{"github.com"} //nolint:gochecknoglobals
 
-	cachedRaw      *regexp.Regexp
-	cachedResource *regexp.Regexp
+	cachedRaw      *regexp.Regexp //nolint:gochecknoglobals
+	cachedResource *regexp.Regexp //nolint:gochecknoglobals
 
 	githubusercontent = regexp.MustCompile(`https://raw.githubusercontent.com/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
 )

--- a/pkg/registry/repositoryhost/resource_url.go
+++ b/pkg/registry/repositoryhost/resource_url.go
@@ -12,14 +12,47 @@ import (
 )
 
 var (
-	rawPrefixed       = regexp.MustCompile(`https://(github.com|github.tools.sap|raw.github.tools.sap|github.wdf.sap.corp)/raw/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
-	resource          = regexp.MustCompile(`https://(github.com|github.tools.sap|raw.github.tools.sap|github.wdf.sap.corp)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?([^\?#]*)(.*)`)
+	// knownHosts holds all GitHub-compatible hosts that docforge can process.
+	// Populated at startup via RegisterHost() for each entry in github-oauth-env-map.
+	// TODO: extend this mechanism to support GitLab hosts when a GitLab implementation is added.
+	knownHosts = []string{"github.com"}
+
+	cachedRaw      *regexp.Regexp
+	cachedResource *regexp.Regexp
+
 	githubusercontent = regexp.MustCompile(`https://raw.githubusercontent.com/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
 )
 
+func init() {
+	cachedRaw, cachedResource = buildRegexps()
+}
+
+func buildRegexps() (*regexp.Regexp, *regexp.Regexp) {
+	escaped := make([]string, len(knownHosts))
+	for i, h := range knownHosts {
+		escaped[i] = regexp.QuoteMeta(h)
+	}
+	hostGroup := strings.Join(escaped, "|")
+	raw := regexp.MustCompile(`https://(` + hostGroup + `)/raw/([^/]+)/([^/]+)/([^/]+)/([^\?#]*)(.*)`)
+	res := regexp.MustCompile(`https://(` + hostGroup + `)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?([^\?#]*)(.*)`)
+	return raw, res
+}
+
+// RegisterHost adds a GitHub-compatible host to the list of recognized hosts.
+// Must be called before any URL parsing occurs (i.e. at startup, before goroutines are started).
+func RegisterHost(host string) {
+	for _, h := range knownHosts {
+		if h == host {
+			return
+		}
+	}
+	knownHosts = append(knownHosts, host)
+	cachedRaw, cachedResource = buildRegexps()
+}
+
 // IsResourceURL checks if link is resource URL
 func IsResourceURL(link string) bool {
-	return rawPrefixed.MatchString(link) || resource.MatchString(link) || githubusercontent.MatchString(link)
+	return cachedRaw.MatchString(link) || cachedResource.MatchString(link) || githubusercontent.MatchString(link)
 }
 
 // IsRelative is a helper function that checks if a link is relative
@@ -63,7 +96,7 @@ func new(resourceURL string) (*URL, error) {
 	if u.String() == "" {
 		return nil, nil
 	}
-	components := rawPrefixed.FindStringSubmatch(u.String())
+	components := cachedRaw.FindStringSubmatch(u.String())
 	if components != nil {
 		return &URL{
 			host:           components[1],
@@ -87,7 +120,7 @@ func new(resourceURL string) (*URL, error) {
 			resourceSuffix: components[5],
 		}, nil
 	}
-	components = resource.FindStringSubmatch(u.String())
+	components = cachedResource.FindStringSubmatch(u.String())
 	if components != nil {
 		return &URL{
 			host:           components[1],

--- a/pkg/registry/repositoryhost/resource_url_test.go
+++ b/pkg/registry/repositoryhost/resource_url_test.go
@@ -140,4 +140,29 @@ var _ = Describe("URL", func() {
 			})
 		})
 	})
+
+	Describe("#RegisterHost", func() {
+		AfterEach(func() {
+			repositoryhost.ResetHosts()
+		})
+
+		It("allows parsing URLs from a newly registered host", func() {
+			repositoryhost.RegisterHost("github.example.com")
+
+			Expect(repositoryhost.IsResourceURL("https://github.example.com/owner/repo/blob/master/docs/readme.md")).To(BeTrue())
+
+			r, err := repositoryhost.NewResourceURL("https://github.example.com/owner/repo/blob/master/docs/readme.md")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r.GetHost()).To(Equal("github.example.com"))
+			Expect(r.GetOwner()).To(Equal("owner"))
+			Expect(r.GetRepo()).To(Equal("repo"))
+		})
+
+		It("rejects URLs from an unregistered host", func() {
+			Expect(repositoryhost.IsResourceURL("https://unknown.example.com/owner/repo/blob/master/docs/readme.md")).To(BeFalse())
+
+			_, err := repositoryhost.NewResourceURL("https://unknown.example.com/owner/repo/blob/master/docs/readme.md")
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
What this PR does / why we need it:
Removes the hardcoded list of GitHub hosts from Docforge and replaces it with a configurable mechanism via --github-oauth-env-map. Previously, only a fixed set of SAP-internal GitHub instances was supported. Teams adopting Docforge for their own pipelines had no way to point it at their own GitHub Enterprise instance without modifying the source code.

Changes

Modified:

pkg/registry/repositoryhost/resource_url.go — replaced hardcoded host list with a dynamic registry; added RegisterHost() to register hosts at startup
cmd/app/initilization.go — calls RegisterHost() for each host configured via --github-oauth-env-map
pkg/registry/repositoryhost/export_test.go — exposed ResetHosts() for test isolation
pkg/registry/repositoryhost/resource_url_test.go — added tests for RegisterHost(): verifies that registered hosts are accepted and unregistered hosts are rejected
Which issue(s) this PR fixes:
Configurable Git Hosts #463

Special notes for your reviewer:
RegisterHost() must be called before any URL parsing occurs. This is guaranteed by the startup sequence in initilization.go which runs before any manifest resolution begins.

Testing:
Verified with a manifest hosted in [VelmiraPetkova/confCitHubHostTest](https://github.com/VelmiraPetkova/confCitHubHostTest) pulling content from [VelmiraPetkova/KCD-Sofia](https://github.com/VelmiraPetkova/KCD-Sofia) — a non-Gardener repository on a separate GitHub profile. Both configured via --github-oauth-env-map "github.com=GITHUB_OAUTH_TOKEN". Dry-run and full run completed successfully — 7 files assembled into the expected output structure.

Release note:
The GitHub host list is no longer hardcoded. Additional GitHub-compatible hosts (e.g. GitHub Enterprise instances) can now be registered via --github-oauth-env-map without modifying the source code. The --persona-filter-enabled flag is unaffected.
