### PR TITLE
Feat/gen toc

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,6 +5,7 @@ aliases:
   - dimitar-kostadinov
   - Kostov6
   - RadaBDimitrova
+  - VelmiraS
   docforge-approvers:
   - dimitar-kostadinov
   - Kostov6

--- a/cmd/app/cmd.go
+++ b/cmd/app/cmd.go
@@ -65,6 +65,8 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	genCmdDocs := gendocs.NewGenCmdDocs()
 	cmd.AddCommand(genCmdDocs)
 
+	cmd.AddCommand(NewGenTocCmd(ctx))
+
 	klog.InitFlags(nil)
 	addFlags(cmd)
 

--- a/cmd/app/gentoc.go
+++ b/cmd/app/gentoc.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gardener/docforge/pkg/gentoc"
+	"github.com/gardener/docforge/pkg/manifest"
+	"github.com/gardener/docforge/pkg/registry"
+	"github.com/gardener/docforge/pkg/registry/repositoryhost"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+type genTocFlags struct {
+	manifestURL    string
+	output         string
+	githubOAuthMap map[string]string
+	cacheDir       string
+	stripRoot      bool
+}
+
+// NewGenTocCmd returns the gen-toc subcommand.
+func NewGenTocCmd(ctx context.Context) *cobra.Command {
+	f := &genTocFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "gen-toc",
+		Short: "Generate a navigation YAML from a Docforge manifest",
+		Long: `Reads a Docforge manifest and derives a navigation structure from it.
+
+The generated YAML reflects the dir / file / fileTree hierarchy defined in the
+manifest. It can be used as input for VitePress, SAP portal (toc.yaml), MkDocs,
+or any other site generator that consumes a navigation file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return runGenToc(ctx, f)
+		},
+	}
+
+	userHomeDir, _ := os.UserHomeDir()
+	defaultCacheDir := filepath.Join(userHomeDir, DocforgeHomeDir)
+
+	cmd.Flags().StringVarP(&f.manifestURL, "manifest", "f", "", "Manifest URL (required).")
+	cmd.Flags().StringVarP(&f.output, "output", "o", "", "Output file path. Prints to stdout when omitted.")
+	cmd.Flags().StringToStringVar(&f.githubOAuthMap, "github-oauth-env-map", map[string]string{},
+		"Map between GitHub instances and ENV variable names that hold access tokens.")
+	cmd.Flags().StringVar(&f.cacheDir, "cache-dir", defaultCacheDir, "Cache directory for repository HTTP cache.")
+	cmd.Flags().BoolVar(&f.stripRoot, "strip-root", false, "Strip the top-level directory prefix from all filenames.")
+
+	if err := cmd.MarkFlagRequired("manifest"); err != nil {
+		klog.Error(err)
+	}
+
+	return cmd
+}
+
+func runGenToc(ctx context.Context, f *genTocFlags) error {
+	initOpts := repositoryhost.InitOptions{
+		EnvCredentials: f.githubOAuthMap,
+		CacheHomeDir:   f.cacheDir,
+	}
+
+	rhs, err := initRepositoryHosts(ctx, initOpts)
+	if err != nil {
+		return fmt.Errorf("failed to initialise repository hosts: %w", err)
+	}
+
+	rhRegistry := registry.NewRegistry(rhs...)
+
+	nodes, err := manifest.ResolveManifest(f.manifestURL, rhRegistry)
+	if err != nil {
+		return fmt.Errorf("failed to resolve manifest %s: %w", f.manifestURL, err)
+	}
+
+	nav := gentoc.FromNodes(nodes, f.stripRoot)
+	out, err := gentoc.Marshal(nav)
+	if err != nil {
+		return fmt.Errorf("failed to marshal navigation YAML: %w", err)
+	}
+
+	if f.output == "" {
+		fmt.Print(string(out))
+		return nil
+	}
+
+	if err := os.WriteFile(f.output, out, 0644); err != nil {
+		return fmt.Errorf("failed to write output file %s: %w", f.output, err)
+	}
+	klog.Infof("Navigation written to %s\n", f.output)
+	return nil
+}

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -62,7 +62,7 @@ Manifest: fileTree.yaml
 structure:
 - dir: section
   structure:
-  # loads all files from a given github directory (tree)
+  # loads all files from a given github directory and all subdirectories (recursively)
   - fileTree: https://github.com/gardener/docforge/tree/master/docs
     # relative paths of files to exclude
     excludeFiles:
@@ -71,10 +71,16 @@ structure:
     - cmd-ref/docforge_completion.md
     - cmd-ref/docforge_gen-cmd-docs.md
 ```
-Result:
+Result: Folders with only images/assets (.png,.jpg, etc.) will be silently skipped.
 ```
 docforge-docs
 └── section
+    └── plugin
+        |── alias.md
+        |── docsy.md
+        |── filetypefilter.md
+        |── markdown.md
+        |── persona.md
     |── consistency.md
     |── manifest-ref.md
     |── manifests.md

--- a/pkg/gentoc/gentoc.go
+++ b/pkg/gentoc/gentoc.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gentoc
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/gardener/docforge/pkg/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+// NavEntry represents one entry in the generated navigation structure.
+type NavEntry struct {
+	Filename string      `yaml:"filename"`
+	Subnav   []*NavEntry `yaml:"subnav,omitempty"`
+}
+
+// Nav is the top-level navigation document.
+type Nav struct {
+	Nav []*NavEntry `yaml:"nav"`
+}
+
+// contentExts is the set of file extensions considered navigation-worthy.
+var contentExts = map[string]bool{ //nolint:gochecknoglobals
+	".md":   true,
+	".html": true,
+}
+
+// FromNodes builds a Nav from the resolved manifest node tree.
+// nodes[0] is expected to be the root node produced by manifest.ResolveManifest.
+// stripRoot removes the top-level directory prefix from all filenames.
+func FromNodes(nodes []*manifest.Node, stripRoot bool) *Nav {
+	root := nodes[0]
+	children := root.Structure
+
+	var stripPrefix string
+	// When the root has exactly one dir child and stripRoot is requested,
+	// skip that dir and strip its name from all descendant paths.
+	if stripRoot && len(children) == 1 && children[0].Type == "dir" {
+		stripPrefix = children[0].NodePath() + "/"
+		children = children[0].Structure
+	}
+
+	return &Nav{Nav: dirEntries(children, stripPrefix)}
+}
+
+// dirEntries converts a slice of sibling nodes into NavEntry slice.
+// Directories that contain a README.md are promoted: the README becomes the
+// entry filename and the remaining siblings become subnav.
+func dirEntries(children []*manifest.Node, stripPrefix string) []*NavEntry {
+	var entries []*NavEntry
+	for _, n := range children {
+		entry := nodeToEntry(n, stripPrefix)
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func nodeToEntry(n *manifest.Node, stripPrefix string) *NavEntry {
+	switch n.Type {
+	case "dir":
+		return dirNode(n, stripPrefix)
+	case "file":
+		return fileNode(n, stripPrefix)
+	default:
+		return nil
+	}
+}
+
+func filename(nodePath, stripPrefix string) string {
+	return strings.TrimPrefix(nodePath, stripPrefix)
+}
+
+// fileNode returns an entry for a file node, or nil for non-content files.
+func fileNode(n *manifest.Node, stripPrefix string) *NavEntry {
+	if !isContentFile(n.NodePath()) {
+		return nil
+	}
+	return &NavEntry{Filename: filename(n.NodePath(), stripPrefix)}
+}
+
+// dirNode converts a dir node to a NavEntry.
+// If the dir contains a README.md (or _index.md), that file becomes the
+// entry filename and its siblings become subnav children.
+// Returns nil if the dir has no navigable content.
+func dirNode(n *manifest.Node, stripPrefix string) *NavEntry {
+	readme, rest := splitReadme(n.Structure)
+	sub := dirEntries(rest, stripPrefix)
+
+	if readme != nil {
+		entry := &NavEntry{Filename: filename(readme.NodePath(), stripPrefix)}
+		if len(sub) > 0 {
+			entry.Subnav = sub
+		}
+		return entry
+	}
+
+	// No README — skip dirs with no navigable content (e.g. assets/).
+	if len(sub) == 0 {
+		return nil
+	}
+	return &NavEntry{Filename: filename(n.NodePath(), stripPrefix), Subnav: sub}
+}
+
+// splitReadme separates the README/index file from the rest of the children.
+func splitReadme(children []*manifest.Node) (readme *manifest.Node, rest []*manifest.Node) {
+	for _, n := range children {
+		if n.Type == "file" && isIndexFile(n.Name()) {
+			readme = n
+		} else {
+			rest = append(rest, n)
+		}
+	}
+	return
+}
+
+func isIndexFile(name string) bool {
+	lower := strings.ToLower(name)
+	return lower == "readme.md" || lower == "_index.md" || lower == "index.md"
+}
+
+func isContentFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return contentExts[ext]
+}
+
+// Marshal serialises nav to YAML bytes.
+func Marshal(nav *Nav) ([]byte, error) {
+	return yaml.Marshal(nav)
+}

--- a/pkg/registry/repositoryhost/github_http_cache.go
+++ b/pkg/registry/repositoryhost/github_http_cache.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -118,6 +119,7 @@ func (p *ghc) Tree(r URL) ([]string, error) {
 			out = append(out, strings.TrimPrefix(url, filterString))
 		}
 	}
+	sort.Strings(out)
 	return out, nil
 }
 


### PR DESCRIPTION
What this PR does / why we need it:

Adds a new gen-toc subcommand that generates a navigation YAML file from a Docforge manifest. The generated structure reflects the dir / file / fileTree hierarchy defined in the manifest and can be used as input for  SAP portal (toc.yaml)

Also fixes a non-deterministic ordering bug in Tree() output caused by Go map iteration randomness — without this fix, repeated runs of gen-toc on the same manifest could produce different orderings.

Which issue(s) this PR fixes:
Fixes ##471

Special notes for your reviewer:

The gen-toc subcommand does not download files — it only resolves the manifest and derives the navigation structure. The --strip-root flag removes the top-level directory prefix from all paths in the output.

The ordering fix in pkg/registry/repositoryhost/github_http_cache.go (sort.Strings(out) in Tree()) is a minimal, safe change — GitHub API already returns entries alphabetically, so the sort produces the same result as preserving API order.

Release note:


Added `gen-toc` subcommand to generate a navigation YAML from a Docforge manifest without downloading any files. Supports VitePress, MkDocs, SAP portal (toc.yaml), and other navigation formats. Use `--strip-root` to remove the top-level directory prefix from all paths.