### PR TITLE
owners: add klocke-io as reviewer and approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,10 +3,12 @@
 aliases:
   docforge-reviewers:
   - dimitar-kostadinov
+  - klocke-io
   - Kostov6
   - RadaBDimitrova
   - VelmiraS
   docforge-approvers:
   - dimitar-kostadinov
+  - klocke-io
   - Kostov6
   - RadaBDimitrova


### PR DESCRIPTION
## Summary

- Add `klocke-io` to `docforge-reviewers` list
- Add `klocke-io` to `docforge-approvers` list
