### PR TITLE
feat: add --clean-destination flag

### DIFF
--- a/cmd/app/exec.go
+++ b/cmd/app/exec.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -54,6 +55,11 @@ func exec(ctx context.Context, vip *viper.Viper) error {
 	}
 
 	config := getReactorConfig(options.Options, options.Hugo, rhs)
+
+	if err := cleanDestination(config.CleanDestination, config.DryRun, config.DestinationPath); err != nil {
+		return err
+	}
+
 	manifestURL := options.ManifestPath
 
 	rhRegistry := registry.NewRegistry(append(localRH, config.RepositoryHosts...)...)
@@ -102,5 +108,18 @@ func exec(ctx context.Context, vip *viper.Viper) error {
 	// Stage 2 ...
 
 	rhRegistry.LogRateLimits(ctx)
+	return nil
+}
+
+func cleanDestination(clean, dryRun bool, destinationPath string) error {
+	if !clean || dryRun {
+		return nil
+	}
+	if destinationPath == "" {
+		return fmt.Errorf("--clean-destination requires --destination to be set")
+	}
+	if err := os.RemoveAll(destinationPath); err != nil {
+		return fmt.Errorf("failed to clean destination %q: %w", destinationPath, err)
+	}
 	return nil
 }

--- a/cmd/app/exec_test.go
+++ b/cmd/app/exec_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanDestination(t *testing.T) {
+	tests := []struct {
+		name            string
+		clean           bool
+		dryRun          bool
+		destination     string
+		setupFiles      []string
+		wantErr         string
+		wantFilesGone   bool
+	}{
+		{
+			name:        "clean=false: destination left untouched",
+			clean:       false,
+			destination: t.TempDir(),
+			setupFiles:  []string{"stale.md"},
+			wantFilesGone: false,
+		},
+		{
+			name:        "dry-run: destination left untouched even when clean=true",
+			clean:       true,
+			dryRun:      true,
+			destination: t.TempDir(),
+			setupFiles:  []string{"stale.md"},
+			wantFilesGone: false,
+		},
+		{
+			name:          "clean=true: destination removed",
+			clean:         true,
+			destination:   t.TempDir(),
+			setupFiles:    []string{"stale.md", "sub/other.md"},
+			wantFilesGone: true,
+		},
+		{
+			name:    "clean=true with empty destination path: returns error",
+			clean:   true,
+			wantErr: "--clean-destination requires --destination to be set",
+		},
+		{
+			name:          "clean=true destination does not exist: no error",
+			clean:         true,
+			destination:   filepath.Join(t.TempDir(), "nonexistent"),
+			wantFilesGone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create setup files inside destination
+			for _, f := range tt.setupFiles {
+				full := filepath.Join(tt.destination, f)
+				if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(full, []byte("content"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err := cleanDestination(tt.clean, tt.dryRun, tt.destination)
+
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("want error %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, f := range tt.setupFiles {
+				full := filepath.Join(tt.destination, f)
+				_, statErr := os.Stat(full)
+				if tt.wantFilesGone && statErr == nil {
+					t.Errorf("expected %s to be gone, but it still exists", f)
+				}
+				if !tt.wantFilesGone && statErr != nil {
+					t.Errorf("expected %s to exist, but got: %v", f, statErr)
+				}
+			}
+		})
+	}
+}

--- a/cmd/app/exec_test.go
+++ b/cmd/app/exec_test.go
@@ -12,27 +12,27 @@ import (
 
 func TestCleanDestination(t *testing.T) {
 	tests := []struct {
-		name            string
-		clean           bool
-		dryRun          bool
-		destination     string
-		setupFiles      []string
-		wantErr         string
-		wantFilesGone   bool
+		name          string
+		clean         bool
+		dryRun        bool
+		destination   string
+		setupFiles    []string
+		wantErr       string
+		wantFilesGone bool
 	}{
 		{
-			name:        "clean=false: destination left untouched",
-			clean:       false,
-			destination: t.TempDir(),
-			setupFiles:  []string{"stale.md"},
+			name:          "clean=false: destination left untouched",
+			clean:         false,
+			destination:   t.TempDir(),
+			setupFiles:    []string{"stale.md"},
 			wantFilesGone: false,
 		},
 		{
-			name:        "dry-run: destination left untouched even when clean=true",
-			clean:       true,
-			dryRun:      true,
-			destination: t.TempDir(),
-			setupFiles:  []string{"stale.md"},
+			name:          "dry-run: destination left untouched even when clean=true",
+			clean:         true,
+			dryRun:        true,
+			destination:   t.TempDir(),
+			setupFiles:    []string{"stale.md"},
 			wantFilesGone: false,
 		},
 		{

--- a/cmd/app/flags.go
+++ b/cmd/app/flags.go
@@ -37,6 +37,10 @@ func configureFlags(command *cobra.Command, vip *viper.Viper) {
 		"Runs the command end-to-end but instead of writing files, it will output the projected file/folder hierarchy to the standard output and statistics for the processing of each file.")
 	_ = vip.BindPFlag("dry-run", command.Flags().Lookup("dry-run"))
 
+	command.Flags().Bool("clean-destination", false,
+		"Remove the destination directory before writing. Ignored when --dry-run is set.")
+	_ = vip.BindPFlag("clean-destination", command.Flags().Lookup("clean-destination"))
+
 	command.Flags().Int("document-workers", 25,
 		"Number of parallel workers for document processing.")
 	_ = vip.BindPFlag("document-workers", command.Flags().Lookup("document-workers"))

--- a/cmd/app/types.go
+++ b/cmd/app/types.go
@@ -20,6 +20,7 @@ type Options struct {
 	ResourceDownloadWorkersCount int      `mapstructure:"download-workers"`
 	GhInfoDestination            string   `mapstructure:"github-info-destination"`
 	DryRun                       bool     `mapstructure:"dry-run"`
+	CleanDestination             bool     `mapstructure:"clean-destination"`
 	ContentFileFormats           []string `mapstructure:"content-files-formats"`
 }
 


### PR DESCRIPTION
## What

Add a `--clean-destination` flag that removes the destination directory before writing the output.

## Why

When docforge runs, it writes files to the destination but never removes files that are no longer part of the manifest. This causes silent drift between the manifest configuration and the actual content of the destination directory.

**Concrete example:**
1. A user runs docforge without `excludeFiles` → `Operations/README.md` is written to the destination
2. The user later adds `excludeFiles: [README.md]` to the manifest
3. docforge runs again — the file is correctly excluded from the new output, but `Operations/README.md` still exists in the destination from the previous run

The same problem occurs when a `fileTree` URL is changed, a `dir` is removed from the manifest, or any other change that results in fewer files being generated. The destination accumulates files indefinitely.

This makes it difficult to trust the destination as a reliable representation of the current manifest, especially in automated pipelines where the destination is committed to a repository and served as documentation.

## Solution

`--clean-destination` removes the destination directory before writing. This guarantees the destination always exactly reflects the current manifest.

> **Note:** Cleaning the destination will delete any manually edited files. This is by design — docforge treats the destination as read-only aggregated output. Documentation should be edited in the source repository, not in the destination.

The flag is a no-op when `--dry-run` is set.

Closes #475

/kind enhancement
/priority 3