### PR TITLE
fix(fswriter): reject paths escaping destination root

### DIFF
--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/gardener/docforge/pkg/manifest"
 	"gopkg.in/yaml.v3"
@@ -39,6 +40,10 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *manifest.Node,
 		docBlob = buf.Bytes()
 	}
 	p := filepath.Join(f.Root, path)
+	root := filepath.Clean(f.Root)
+	if rel, err := filepath.Rel(root, filepath.Clean(p)); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path traversal: %q escapes destination root", path)
+	}
 	if len(docBlob) == 0 {
 		return nil
 	}

--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -54,6 +54,9 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *manifest.Node,
 		name = fmt.Sprintf("%s.%s", name, f.Ext)
 	}
 	filePath := filepath.Join(p, name)
+	if rel, err := filepath.Rel(root, filepath.Clean(filePath)); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path traversal: %q escapes destination root", name)
+	}
 	if err := os.WriteFile(filePath, docBlob, 0644); err != nil {
 		return fmt.Errorf("error writing %s: %v", filePath, err)
 	}

--- a/pkg/writers/fswriter.go
+++ b/pkg/writers/fswriter.go
@@ -27,22 +27,14 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *manifest.Node,
 	if slices.Contains(IndexFileNames, name) {
 		name = "_index.md"
 	}
-	//generate _index.md content
-	if f.Hugo && name == "_index.md" && node != nil && node.Frontmatter != nil && docBlob == nil {
-		buf := bytes.Buffer{}
-		_, _ = buf.Write([]byte("---\n"))
-		fm, err := yaml.Marshal(node.Frontmatter)
-		if err != nil {
-			return err
-		}
-		_, _ = buf.Write(fm)
-		_, _ = buf.Write([]byte("---\n"))
-		docBlob = buf.Bytes()
+	var err error
+	if docBlob, err = f.hugoIndexContent(name, node, docBlob); err != nil {
+		return err
 	}
-	p := filepath.Join(f.Root, path)
 	root := filepath.Clean(f.Root)
-	if rel, err := filepath.Rel(root, filepath.Clean(p)); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("path traversal: %q escapes destination root", path)
+	p := filepath.Join(f.Root, path)
+	if err := checkContainment(root, p, path); err != nil {
+		return err
 	}
 	if len(docBlob) == 0 {
 		return nil
@@ -54,11 +46,34 @@ func (f *FSWriter) Write(name, path string, docBlob []byte, node *manifest.Node,
 		name = fmt.Sprintf("%s.%s", name, f.Ext)
 	}
 	filePath := filepath.Join(p, name)
-	if rel, err := filepath.Rel(root, filepath.Clean(filePath)); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("path traversal: %q escapes destination root", name)
+	if err := checkContainment(root, filePath, name); err != nil {
+		return err
 	}
 	if err := os.WriteFile(filePath, docBlob, 0644); err != nil {
 		return fmt.Errorf("error writing %s: %v", filePath, err)
+	}
+	return nil
+}
+
+func (f *FSWriter) hugoIndexContent(name string, node *manifest.Node, docBlob []byte) ([]byte, error) {
+	if !f.Hugo || name != "_index.md" || node == nil || node.Frontmatter == nil || docBlob != nil {
+		return docBlob, nil
+	}
+	buf := bytes.Buffer{}
+	_, _ = buf.Write([]byte("---\n"))
+	fm, err := yaml.Marshal(node.Frontmatter)
+	if err != nil {
+		return nil, err
+	}
+	_, _ = buf.Write(fm)
+	_, _ = buf.Write([]byte("---\n"))
+	return buf.Bytes(), nil
+}
+
+func checkContainment(root, target, label string) error {
+	rel, err := filepath.Rel(root, filepath.Clean(target))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path traversal: %q escapes destination root", label)
 	}
 	return nil
 }

--- a/pkg/writers/fswriter_test.go
+++ b/pkg/writers/fswriter_test.go
@@ -78,3 +78,67 @@ func TestWrite(t *testing.T) {
 		})
 	}
 }
+
+func TestWritePathTraversal(t *testing.T) {
+	cases := []struct {
+		name     string
+		fileName string
+		path     string
+		wantErr  bool
+	}{
+		{
+			name:     "shallow traversal is rejected",
+			fileName: "payload.txt",
+			path:     "../OUTSIDE-ROOT",
+			wantErr:  true,
+		},
+		{
+			name:     "deep traversal is rejected",
+			fileName: "authorized_keys",
+			path:     "../../../../tmp/pwn",
+			wantErr:  true,
+		},
+		{
+			name:     "legitimate nested path is allowed",
+			fileName: "readme.md",
+			path:     "docs/sub",
+			wantErr:  false,
+		},
+		{
+			name:     "directory name starting with .. without separator is allowed",
+			fileName: "file.md",
+			path:     "..config",
+			wantErr:  false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			root := filepath.Join(os.TempDir(), fmt.Sprintf("fswriter-test-%s", uuid.New().String()))
+			defer os.RemoveAll(root)
+
+			w := &FSWriter{Root: root}
+			err := w.Write(c.fileName, c.path, []byte("test-content"), nil, nil)
+
+			if c.wantErr && err == nil {
+				t.Errorf("expected error for path %q but got none", c.path)
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("unexpected error for path %q: %v", c.path, err)
+			}
+
+			if c.wantErr {
+				escaped := filepath.Join(filepath.Clean(root), c.path, c.fileName)
+				if _, statErr := os.Stat(escaped); statErr == nil {
+					t.Errorf("file was written at %q despite traversal rejection", escaped)
+				}
+			}
+
+			if !c.wantErr {
+				expected := filepath.Join(root, c.path, c.fileName)
+				if _, statErr := os.Stat(expected); os.IsNotExist(statErr) {
+					t.Errorf("expected file at %q but it was not written", expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/writers/fswriter_test.go
+++ b/pkg/writers/fswriter_test.go
@@ -110,6 +110,12 @@ func TestWritePathTraversal(t *testing.T) {
 			path:     "..config",
 			wantErr:  false,
 		},
+		{
+			name:     "traversal via file name is rejected",
+			fileName: "../../../sibling-secret",
+			path:     "docs",
+			wantErr:  true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Adds a containment check in FSWriter.Write to reject paths that escape the configured destination root. Without this check, a manifest with a dir: value (e.g. ../../etc) causes docforge to write files outside the intended output directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The fix is in FSWriter.Write — centralized sink that covers all current and future call sites. filepath.Rel is used (not filepath.IsLocal) because it validates the resolved path after Join, not the raw input. The downloader pipeline is not affected — it routes through url.JoinPath which already strips .. components.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user

```
