### PR TITLE
fix(docs): update installation instructions to extract binary from tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ Go to the [latest release](https://github.com/gardener/docforge/releases/latest)
 | Linux | arm64 | `docforge-linux-arm64` |
 | Windows | x86 | `docforge-windows-386` |
 
-Make the binary executable and place it on your PATH. Example for Linux/macOS:
+Download the archive, extract the binary, and place it on your PATH. Example for Linux/macOS:
 
 ```sh
-# Replace <VERSION> and <BINARY> with the values for your platform
-curl -Lo /usr/local/bin/docforge \
+# Replace <BINARY> with the binary name for your platform from the table above
+curl -Lo /tmp/docforge.tar.gz \
   https://github.com/gardener/docforge/releases/latest/download/<BINARY>
-chmod +x /usr/local/bin/docforge
+tar -xzf /tmp/docforge.tar.gz -C /tmp
+chmod +x /tmp/<BINARY>
+sudo mv /tmp/<BINARY> /usr/local/bin/docforge
 ```
 
 > **Disclaimer on releases**: Until there is a stable 1.0 version changes are likely to occur and not necessarily backwards compatible. New features are released with a minor version increase. We do not release hotfixes except for the latest minor release, only for bugs and only when critical.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Release artifacts published to GitHub are gzip tarballs, not plain executables. The previous installation instructions only ran chmod +x on the downloaded file, which caused an exec format error when users tried to run it. This PR updates the README to include the tar -xzf extraction step.

**Which issue(s) this PR fixes**:
Fixes #495

**Special notes for your reviewer**:

**Release note**:

<!--  Write your release note:

The build pipeline in .github/workflows/build.yaml intentionally packages each binary into a docforge.tar.gz before publishing as an OCM resource. The fix is purely in the documentation.
Format of block header: <category> <target_group>

Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Installation instructions in the README now correctly include extracting the binary from the downloaded tarball before running it.
```
